### PR TITLE
Fix code samples

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -4274,9 +4274,9 @@ and which ones are only there to keep the code from crashing.
 Support this by giving things that have no meaning obvious names and values, for example:
 
 ```ABAP
-DATA(alert_id) = '42'.                  " well-known meaningless numbers
-DATA(detection_object_type) = '?=/"&'.  " 'keyboard accidents'
-CONSTANTS some_random_number = 782346.  " revealing variable names
+DATA(alert_id) = '42'.                             " well-known meaningless numbers
+DATA(detection_object_type) = '?=/"&'.             " 'keyboard accidents'
+CONSTANTS some_random_number TYPE i VALUE 782346.  " revealing variable names
 ```
 
 Don't trick people into believing something connects to real objects or real customizing if it doesn't:
@@ -4285,7 +4285,7 @@ Don't trick people into believing something connects to real objects or real cus
 " anti-pattern
 DATA(alert_id) = '00000001223678871'.        " this alert really exists
 DATA(detection_object_type) = 'FRA_SCLAIM'.  " this detection object type, too
-CONSTANTS memory_limit = 4096.               " this number looks carefully chosen
+CONSTANTS memory_limit TYPE i VALUE 4096.    " this number looks carefully chosen
 ```
 
 #### Make it easy to spot differences


### PR DESCRIPTION
The two used to be `DATA(...)` assignments that were turned into `CONSTANTS` declarations, while forgetting to adjust the value part. https://github.com/SAP/styleguides/issues/12