### PR TITLE
Imrove Use Booleans wisely

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -1671,7 +1671,7 @@ CLASS /clean/some_api DEFINITION PUBLIC FINAL CREATE PRIVATE.
 
 We agree that this contradicts itself.
 However, according to the article
-[_Instance Constructor_ of the ABAP Help](https://ldcifri.wdf.sap.corp:44300/sap/public/bc/abap/docu?input=guideline&format=standard&object=abeninstance_constructor_guidl&sap-language=EN&sap-client=100&full_text=X&tree=x),
+[_Instance Constructor_ of the ABAP Help](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abeninstance_constructor_guidl.htm),
 specifying the `CONSTRUCTOR` in the `PUBLIC SECTION` is required to guarantee correct compilation and syntax validation.
 
 This applies only to global classes.

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -1060,7 +1060,7 @@ assert_true( xsdbool( document->is_archived( ) = abap_true AND
                       document->is_partially_archived( ) = abap_true ) ).
 ```
 
-[Split methods instead of Boolean input parameter](#split-methods-instead-of-boolean-input-parameter)
+[Split method instead of Boolean input parameter](#split-method-instead-of-boolean-input-parameter)
 moreover explains why you should always challenge Boolean parameters.
 
 > Read more in
@@ -1673,7 +1673,7 @@ CLASS /clean/some_api DEFINITION PUBLIC FINAL CREATE PRIVATE.
 
 We agree that this contradicts itself.
 However, according to the article
-[_Instance Constructor_ of the ABAP Help](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abeninstance_constructor_guidl.htm),
+[_Instance Constructor_ of the ABAP Help](https://ldcifri.wdf.sap.corp:44300/sap/public/bc/abap/docu?input=guideline&format=standard&object=abeninstance_constructor_guidl&sap-language=EN&sap-client=100&full_text=X&tree=x),
 specifying the `CONSTRUCTOR` in the `PUBLIC SECTION` is required to guarantee correct compilation and syntax validation.
 
 This applies only to global classes.

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -1065,8 +1065,6 @@ moreover explains why you should always challenge Boolean parameters.
 
 > Read more in
 > [1](http://www.beyondcode.org/articles/booleanVariables.html)
-> [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
-> [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Use ABAP_BOOL for Booleans
 
@@ -1869,6 +1867,7 @@ and repeating the parameter name may further understandability:
 
 ```ABAP
 car->drive( speed = 50 ).
+update( asynchronous = abap_true ).
 ```
 
 ### Methods: Object orientation
@@ -2233,10 +2232,10 @@ tend to obscure the parameter's meaning.
 
 ```ABAP
 " anti-pattern
-update( abap_true ).
+update( abap_true ).  " what does 'true' mean? synchronous? simulate? commit?
 ```
 
-Splitting the method may simplify the method's code 
+Splitting the method may simplify the methods' code 
 and describe the different intentions better
 
 ```ABAP
@@ -2251,6 +2250,11 @@ METHODS set_is_deleted
   IMPORTING
     new_value TYPE abap_bool.
 ```
+
+> Read more in
+> [1](http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Parameter Names
 

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2218,21 +2218,26 @@ Do not use `CHANGING` parameters to initially fill a previously empty variable.
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Parameter Types](#parameter-types) > [This section](#split-method-instead-of-boolean-input-parameter)
 
-Boolean input parameters are often an indicator that the method does _two_ things instead of one.
-Challenge these parameters and investigate whether it would make more sense to split the method.
-
-```ABAP
-METHODS update_without_saving.
-METHODS update_and_save.
-```
-
-may be clearer than
+Boolean input parameters are often an indicator
+that a method does _two_ things instead of one.
+Also, method calls with a single - and thus unnamed - Boolean parameter
+tend to obscure the parameter's meaning.
 
 ```ABAP
 " anti-pattern
 METHODS update
   IMPORTING
     do_save TYPE abap_bool.
+
+update( abap_true ).
+```
+
+Splitting the method may simplify the method's code 
+and describe the different intentions better
+
+```ABAP
+update_without_saving( ).
+update_and_save( ).
 ```
 
 Common perception suggests that setters for Boolean variables are okay:

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2220,15 +2220,19 @@ Do not use `CHANGING` parameters to initially fill a previously empty variable.
 
 Boolean input parameters are often an indicator
 that a method does _two_ things instead of one.
-Also, method calls with a single - and thus unnamed - Boolean parameter
-tend to obscure the parameter's meaning.
 
 ```ABAP
 " anti-pattern
 METHODS update
   IMPORTING
     do_save TYPE abap_bool.
+```
 
+Also, method calls with a single - and thus unnamed - Boolean parameter
+tend to obscure the parameter's meaning.
+
+```ABAP
+" anti-pattern
 update( abap_true ).
 ```
 


### PR DESCRIPTION
In response to https://github.com/SAP/styleguides/issues/14. 

- Fixed the link to section _Split method instead of Boolean parameter_
- Added examples that show how two methods are clearer than one unnamed Boolean parameter
- Distributed the Read More links to more appropriate places