### PR TITLE
Exceptions

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2987,16 +2987,10 @@ This exception type _must_ be given in method signatures and _must_ be caught or
 It is therefore plain to see for the consumer and ensures that (s)he won't be surprised by an unexpected exception
 and will take care of reacting to the error situation.
 
-> This guideline contradicts [Robert C. Martin's _Clean Code_],
-> which recommends to resort to unchecked exceptions
-> in all cases to facilitate refactoring.
-> This is because ABAP's unchecked exceptions
-> `CX_DYNAMIC_CHECK` and `CX_NO_CHECK` behave differently than Java's:
-> While Java allows declaring unchecked exceptions on methods
-> if you want to, ABAP forbids this.
-> As a consequence,
-> Java is able to warn consumers of potential exceptions,
-> while ABAP isn't.
+> This is in sync with the [ABAP Programming Guidelines](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abenexception_category_guidl.htm)
+> but contradicts [Robert C. Martin's _Clean Code_],
+> which recommends to prefer unchecked exceptions;
+> [Exceptions](sub-sections/Exceptions.md) explains why.
 
 #### Throw CX_NO_CHECK for usually unrecoverable situations
 

--- a/clean-abap/sub-sections/Exceptions.md
+++ b/clean-abap/sub-sections/Exceptions.md
@@ -1,8 +1,8 @@
 # Exceptions
 
 What type of exception to use for what is a hot topic
-that has been discussed controversially throughout the years,
-with no end in sight.
+that has been discussed controversially
+across time and programming languages.
 
 ## The Ideal
 

--- a/clean-abap/sub-sections/Exceptions.md
+++ b/clean-abap/sub-sections/Exceptions.md
@@ -1,79 +1,135 @@
 # Exceptions
 
-What type of exception to use is a hot topic
-that has been discussed several times,
-for example in [Issue 16](https://github.com/SAP/styleguides/issues/16).
-
-This page describes the reasoning behind our current recommendations.
+What type of exception to use for what is a hot topic
+that has been discussed controversially throughout the years,
+with no end in sight.
 
 ## The Ideal
 
 According to discussions in the community,
-the optimal way to deal with exceptions would be:
+the optimal way to deal with exceptions would be as follows.
+
+First, we want to declare the exception in
+the `lower_method` that actually throws it,
+to not surprise callers:
+
 
 ```ABAP
 METHODS lower_method
   RAISING
-    cx_flexible_exception.
+    /clean/flexible_exception.
 
 METHOD lower_method.
-  RAISE EXCEPTION NEW cx_flexible_exception( ).
+  RAISE EXCEPTION NEW /clean/flexible_exception( ).
 ENDMETHOD:
+```
+
+Then we want to let the exception bubble upwards through `middle_method`s
+without forcing them to redeclare or catch the exception,
+to avoid refactoring cascades if exceptions change:
+
+```ABAP
+METHODS middle_method.
 
 METHOD middle_method.
   lower_method( ).
 ENDMETHOD.
+```
+
+Finally, we want to catch the exception in some `upper_method` and handle it.
+
+```ABAP
+METHODS upper_method.
 
 METHOD upper_method.
   TRY.
       middle_method( ).
-    CATCH cx_flexible_exception.
+    CATCH /clean/flexible_exception.
       " ...
   ENDTRY.
 ENDMETHOD.
 ```
 
-We want to declare the exception in
-the `lower_method` that actually throws it,
-to not surprise callers.
-
-Then we want to let the exception bubble upwards through `middle_method`s
-without forcing them to redeclare or catch the exception.
-This avoids refactoring cascades if exceptions change.
-
-Finally, we want to catch the exception in some `upper_method` and handle it.
-
-This is also exactly what Robert C. Martin advertises for Java.
+This is also exactly what Robert C. Martin advertises for Java,
+where this pattern can be implemented with [unchecked exceptions](https://docs.oracle.com/javase/7/docs/api/java/lang/RuntimeException.html).
 
 ## What's in the Way
 
-However, excactly this way is not possible in ABAP
+Excactly this ideal way is not possible in ABAP
 because none of the available three exception types supports it:
 
-- `cx_static_check` forces `middle_method`
-to redeclare the `cx_flexible_exception`.
-Although this is "only a warning",
-it results in an issue with Very High priority
+### Why CX_STATIC_CHECK Doesn't Help
+
+`cx_static_check` would force `middle_method`
+to redeclare the `/clean/flexible_exception`.
+Although the syntax check throws "only" a warning,
+the ABAP Test Cockpit responds with an issue with Very High priority
 that will prevent transport release in standard system setups.
-Even if you are willing to accept this,
-the code will not actually work but dump in `middle_method`
-because there is no catch block.
 
-- `cx_dynamic_check` doesn't improve this.
-Alhough it accepts the missing redeclaration
+Even if we were willing to accept this,
+`middle_method` would not simply forward `/clean/flexible_exception`
+if it actually occurred,
+but trigger a `cx_sy_no_handler` exception
+which ultimately leads to a dump.
+
+### Why CX_DYNAMIC_CHECK Doesn't Help
+
+`cx_dynamic_check` doesn't improve this.
+Alhough it makes the syntax check accept the missing redeclaration
 and catch block in `middle_method`,
-the code will still dump here if the exception is actually thrown.
+the code will still trigger `cx_sy_no_handler`
+if the exception is actually thrown.
 
-- `cx_no_check` also doesn't help.
-Although the method bodies work,
+### Why CX_NO_CHECK Doesn't Help
+
+`cx_no_check` also doesn't help.
+Although it makes the method bodies work,
 the `METHODS lower_method` definition now is
-no longer allowed to declare `cx_flexible_exception`
+no longer allowed to declare `/clean/flexible_exception`
 and compilation fails with a syntax error.
 
-## The Compromise
+### Why CX_SY_NO_HANDLER Doesn't Help
+
+Catching the special exception `cx_sy_no_handler`
+is a workaround that appears to get pretty near to the ideal way,
+but also adds some imperfections that make it hard to recommend it:
+
+```ABAP
+METHOD upper_method.
+  TRY.
+      middle_method( ).
+    CATCH cx_sy_no_handler INTO DATA(outer).
+      DATA(inner) = outer->previous.
+      " identify and branch on inner's type
+  ENDTRY.
+ENDMETHOD.
+```
+
+`cx_sy_no_handler` prevents using multiple `catch` branches
+to handle different exceptions in different ways.
+
+The code required to identify the actual exception -
+either a series of trial-and-error casts,
+or an RTTI request for the class name, followed by case branches -
+is rather bulky and repetitive.
+
+Catching `cx_sy_no_handler` everywhere also dilutes its original purpose -
+to allow frameworks to handle bad plug-in code -
+a case that you then may have to handle differently.
+
+## Compromises
 
 Community discussions suggest that
-they will rather accept refactoring cascades
-than be surprised by undeclared exceptions.
+people rather accept refactoring cascades
+than being surprised by undeclared exceptions.
 As a consequence, we suggest to prefer checked exceptions
-to unchecked ones.
+to unchecked ones in the way described in the guide.
+
+A different sort of compromise is the mixed-case scenario:
+use unchecked exceptions for _internal_ methods
+that are fully under your team's control
+and where people anticipate them,
+and resort to checked exceptions for _borderline_ methods
+that may be called from outside stakeholders,
+to clearly communicate where something can go wrong.
+

--- a/clean-abap/sub-sections/Exceptions.md
+++ b/clean-abap/sub-sections/Exceptions.md
@@ -1,0 +1,79 @@
+# Exceptions
+
+What type of exception to use is a hot topic
+that has been discussed several times,
+for example in [Issue 16](https://github.com/SAP/styleguides/issues/16).
+
+This page describes the reasoning behind our current recommendations.
+
+## The Ideal
+
+According to discussions in the community,
+the optimal way to deal with exceptions would be:
+
+```ABAP
+METHODS lower_method
+  RAISING
+    cx_flexible_exception.
+
+METHOD lower_method.
+  RAISE EXCEPTION NEW cx_flexible_exception( ).
+ENDMETHOD:
+
+METHOD middle_method.
+  lower_method( ).
+ENDMETHOD.
+
+METHOD upper_method.
+  TRY.
+      middle_method( ).
+    CATCH cx_flexible_exception.
+      " ...
+  ENDTRY.
+ENDMETHOD.
+```
+
+We want to declare the exception in
+the `lower_method` that actually throws it,
+to not surprise callers.
+
+Then we want to let the exception bubble upwards through `middle_method`s
+without forcing them to redeclare or catch the exception.
+This avoids refactoring cascades if exceptions change.
+
+Finally, we want to catch the exception in some `upper_method` and handle it.
+
+This is also exactly what Robert C. Martin advertises for Java.
+
+## What's in the Way
+
+However, excactly this way is not possible in ABAP
+because none of the available three exception types supports it:
+
+- `cx_static_check` forces `middle_method`
+to redeclare the `cx_flexible_exception`.
+Although this is "only a warning",
+it results in an issue with Very High priority
+that will prevent transport release in standard system setups.
+Even if you are willing to accept this,
+the code will not actually work but dump in `middle_method`
+because there is no catch block.
+
+- `cx_dynamic_check` doesn't improve this.
+Alhough it accepts the missing redeclaration
+and catch block in `middle_method`,
+the code will still dump here if the exception is actually thrown.
+
+- `cx_no_check` also doesn't help.
+Although the method bodies work,
+the `METHODS lower_method` definition now is
+no longer allowed to declare `cx_flexible_exception`
+and compilation fails with a syntax error.
+
+## The Compromise
+
+Community discussions suggest that
+they will rather accept refactoring cascades
+than be surprised by undeclared exceptions.
+As a consequence, we suggest to prefer checked exceptions
+to unchecked ones.

--- a/clean-abap/sub-sections/Exceptions.md
+++ b/clean-abap/sub-sections/Exceptions.md
@@ -130,6 +130,5 @@ use unchecked exceptions for _internal_ methods
 that are fully under your team's control
 and where people anticipate them,
 and resort to checked exceptions for _borderline_ methods
-that may be called from outside stakeholders,
+that may be called from other stakeholders,
 to clearly communicate where something can go wrong.
-


### PR DESCRIPTION
In response to https://github.com/SAP/styleguides/issues/16. An attempt to clarify the reasoning behind the recommended use of the three exception categories.