### PR TITLE
Removed mention of the SAP-internal Avalon test framework

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -4152,15 +4152,19 @@ ENDMETHOD.
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Testing](#testing) > [Injection](#injection) > [This section](#exploit-the-test-tools)
 
-In general, a clean programming style will let you do much of the work with standard ABAP unit tests and test doubles.
-However, there are several tools that will allow you to tackle trickier cases in elegant ways:
+In general, a clean programming style
+will let you do much of the work
+with standard ABAP unit tests and test doubles.
+However, there are tools that will allow you
+to tackle trickier cases in elegant ways:
 
-- Use the `CL_OSQL_REPLACE` service to test complex OpenSQL statements by redirecting them to a test data bin
-that can be filled with test data without interfering with the rest of the system.
+- Use the `CL_OSQL_REPLACE` service
+to test complex OpenSQL statements
+by redirecting them to a test data bin
+that can be filled with test data
+without interfering with the rest of the system.
 
 - Use the CDS test framework to test your CDS views.
-
-- Use Avalon to test AMDPs and HANA-native database procedures.
 
 #### Use test seams as temporary workaround
 


### PR DESCRIPTION
In response to https://github.com/SAP/styleguides/issues/36, removing mention of the _Avalon_ test framework for AMDPs because it is only available internally at SAP.

Avalon was an early prototype for the publicly available CDS Test Double Framework. Its future is unclear; although it's still bug-fixed, feature development goes into the CDS Test Double Framework.

Due to some design differences, Avalon was able to mock/test AMDPs, which is - as of now - not possible with the CDS Test Double Framework.