### PR TITLE
Modern ABAP Language Elements

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -32,7 +32,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
   - [Mind the legacy](#mind-the-legacy)
   - [Mind the performance](#mind-the-performance)
   - [Prefer object orientation to procedural programming](#prefer-object-orientation-to-procedural-programming)
-  - [Prefer functional to procedural language constructs](#prefer-functional-to-procedural-language-constructs)
+  - [Prefer modern language constructs](#prefer-modern-language-constructs)
   - [Avoid obsolete language elements](#avoid-obsolete-language-elements)
   - [Use design patterns wisely](#use-design-patterns-wisely)
 - [Constants](#constants)
@@ -587,9 +587,9 @@ ENDFUNCTION.
 > [Function Groups vs. Classes](sub-sections/FunctionGroupsVsClasses.md)
 > describes the differences in detail.
 
-### Prefer functional to procedural language constructs
+### Prefer modern language constructs
 
-> [Clean ABAP](#clean-abap) > [Content](#content) > [Language](#language) > [This section](#prefer-functional-to-procedural-language-constructs)
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Language](#language) > [This section](#prefer-modern-language-constructs)
 
 They are usually shorter and come more natural to modern programmers.
 
@@ -621,7 +621,8 @@ IF line_exists( value_pairs[ name = 'A' ] ).
 " DATA(exists) = xsdbool( sy-subrc = 0 ).
 ```
 
-Many of the detailed rules below are just specific reiterations of this general advice.
+[Modern ABAP Language Elements](sub-sections/ModernABAPLanguageElements.md)
+describes the most helpful language additions of the past years.
 
 ### Avoid obsolete language elements
 

--- a/clean-abap/sub-sections/ModernABAP.md
+++ b/clean-abap/sub-sections/ModernABAP.md
@@ -13,30 +13,30 @@ For more information please consult the ABAP online documentation.
 ## Table of Contents
 
 - [Functional statements and expressions in ABAP](#functional-statements-and-expressions-in-abap)
-  - [Inline declaration of variables](#inline-declaration-of-variables)
-  - [Compound Assignment Operators](#compound-assignment-operators)
-  - [Booleans](#booleans)
-  - [Enumerations](#enumerations)
-  - [Internal Tables](#internal-tables)
-    - [Count table lines](#count-table-lines)
-    - [Check existence of a table line](#check-existence-of-a-table-line)
-    - [Access table key with uncertain result](#access-table-key-with-uncertain-result)
-    - [Access table index](#access-table-index)
-  - [Conditions](#conditions)
-    - [Conditional distinction](#conditional-distinction)
-    - [Case distinction](#case-distinction)
-    - [Case distinctions of reference types class and interface](#case-distinctions-of-reference-types-class-and-interface)
-  - [Conversions](#conversions)
-    - [Cast data references](#cast-data-references)
-    - [Create data references](#create-data-references)
-    - [Convert data types](#convert-data-types)
-    - [Copy fields with matching names](#copy-fields-with-matching-names)
-  - [Constructors](#constructors)
-    - [Construct objects and data](#construct-objects-and-data)
-    - [Construct data types](#construct-data-types)
-    - [Filter tables](#filter-tables)
-  - [Character Handling](#character-handling)
-    - [Lower and upper case conversion](#lower-and-upper-case-conversion)
+- [Inline declaration of variables](#inline-declaration-of-variables)
+- [Compound Assignment Operators](#compound-assignment-operators)
+- [Booleans](#booleans)
+- [Enumerations](#enumerations)
+- [Internal Tables](#internal-tables)
+  - [Count lines](#count-table-lines)
+  - [Check existence of a table line](#check-existence-of-a-table-line)
+  - [Access table key with uncertain result](#access-table-key-with-uncertain-result)
+  - [Access table index](#access-table-index)
+- [Conditions](#conditions)
+  - [Conditional distinction](#conditional-distinction)
+  - [Case distinction](#case-distinction)
+  - [Case distinctions of reference types class and interface](#case-distinctions-of-reference-types-class-and-interface)
+- [Conversions](#conversions)
+  - [Cast data references](#cast-data-references)
+  - [Create data references](#create-data-references)
+  - [Convert data types](#convert-data-types)
+  - [Copy fields with matching names](#copy-fields-with-matching-names)
+- [Constructors](#constructors)
+  - [Construct objects and data](#construct-objects-and-data)
+  - [Construct data types](#construct-data-types)
+  - [Filter tables](#filter-tables)
+- [Character Handling](#character-handling)
+  - [Lower and upper case conversion](#lower-and-upper-case-conversion)
 - [Flow control](#flow-control)
   - [Loop with control break](#loop-with-control-break)
 - [Interface implementation](#interface-implementation)
@@ -58,9 +58,12 @@ if the compiler can determine the data type from the context.
 > are very powerful and versatile in their usage.
 > When using them, always keep the clean code principles in mind.
 
-### Inline declaration of variables
+## Inline declaration of variables
 
-Use the operators `data` and `field-symbol`
+Use the operators
+[`DATA`](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abendata_inline.htm)
+and
+[`FIELD-SYMBOL`](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-us/abenfield-symbol_inline.htm)
 to combine the declaration and initial value assignment
 of a variable or field symbol.
 
@@ -125,7 +128,7 @@ ENDLOOP.
 ASSIGN COMPONENT id OF acount_sap TO FIELD-SYMBOL(<account_id>).
 
 " old style
-FIELD-SYMBOL <account_id> TYPE account_structure.
+FIELD-SYMBOL <account_id> TYPE account_id_type.
 ASSIGN COMPONENT id OF acount_sap TO <account_id>.
 ```
 
@@ -136,72 +139,76 @@ SELECT * FROM t000 INTO TABLE @DATA(clients).
 DATA clients TYPE STANDARD TABLE OF t000.
 SELECT * FROM t000 INTO TABLE clients.
 ```
-### Compound Assignment Operators
-Shorthand versions of arithmetic assignments and string concatenation.
+## Compound Assignment Operators
+
+SAP NetWeaver 7.54 introduces shorthand versions
+for arithmetic assignments and string concatenation.
 These assignments also allow expressions in the operand position.
 
-| Name | Shorthand operator  | Meaning  |
-|---|---|---|
-| Addition assignment  | x += 1.  | x = x + 1.  |
-| Substraction assignment  | x -= 1.  | x = x - 1.  |
-| Multiplication assignment | x *= 1.  | x = x * 1.  |
-| Division assignment  | x /= 1.  | x = x / 1.  |
-| String assignment | x &&= \|abc\|. | x = x && \|abc\|. |
+Shorthand | Longhand  |
+---|---|
+x += 1.  | x = x + 1.  |
+x -= 1.  | x = x - 1.  |
+x *= 1.  | x = x * 1.  |
+x /= 1.  | x = x / 1.  |
+x &&= \`abc\`. | x = x && \`abc\`. |
 
-### Booleans
+## Non-Initial Conditions
 
-Comparison with the type `abap_bool` can be omitted in conditions.
+The comparison `IS INITIAL` can be omitted in certain places.
+This can, for example, be used to shorten Boolean comparisons:
 
 ```ABAP
-if method_returns_abap_bool( ).
-  "method returned abap_true
-else.
-  "method returned abap_false
-endif.
+IF is_valid( ).
+  " method returned abap_true
+ELSE.
+  " method returned abap_false = IS INITIAL
+ENDIF.
 ```
 
-### Enumerations
+## Enumerations
 
 Define enumerations instead of using constants.
 
 ```ABAP
-types: begin of enum scrum_status_type,
-         open,
-         in_progress,
-         blocked,
-         done,
-       end of enum scrum_status_type.
+TYPES:
+  BEGIN OF ENUM scrum_status_type,
+    open,
+    in_progress,
+    blocked,
+    done,
+  END OF ENUM scrum_status_type.
 
-data(scrum_status) = open.
+DATA(scrum_status) = open.
 ```
 
 Old style:
 
 ```ABAP
-constants scrum_status_open       type i value 1.
-constants scrum_status_in_process type i value 2.
-constants scrum_status_blocked    type i value 3.
-constants scrum_status_done       type i value 4.
-data scrum status type i.
+CONSTANTS scrum_status_open       TYPE i VALUE 1.
+CONSTANTS scrum_status_in_process TYPE i VALUE 2.
+CONSTANTS scrum_status_blocked    TYPE i VALUE 3.
+CONSTANTS scrum_status_done       TYPE i u 4.
+DATA scrum status TYPE i.
 
 scrum_status = scrum_status_open.
 ```
 
-### Internal Tables
+## Internal Tables
 
-#### Count table lines
+### Count lines
 
-Count the number of lines of an internal table use  the function `lines( )`.
+Count the number of lines of an internal table with [`lines( )`](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abendescriptive_functions_table.htm).
 
 ```ABAP
-data(number_of_lines) = lines( accounts ).
+DATA(number_of_lines) = lines( accounts ).
 ```
 
 Old style:
 
 ```ABAP
-data number_of_lines type i.
-describe table accounts lines number_of_lines.
+DATA number_of_lines TYPE i.
+DESCRIBE TABLE accounts LINES number_of_lines.
 ```
 
 #### Check existence of a table line

--- a/clean-abap/sub-sections/ModernABAP.md
+++ b/clean-abap/sub-sections/ModernABAP.md
@@ -1,0 +1,616 @@
+# Modern ABAP Language Elements
+
+As the ABAP language evolves,
+new features often go unnoticed by developers.
+This document highlights some of the additions
+that improve readability of the code
+and therefore should be in the tool set
+of any professional ABAPer.
+
+The new ABAP statements are not described to full detail.
+For more information please consult the ABAP online documentation.
+
+## Table of Contents
+
+- [Functional statements and expressions in ABAP](#functional-statements-and-expressions-in-abap)
+  - [Inline declaration of variables](#inline-declaration-of-variables)
+  - [Compound Assignment Operators](#compound-assignment-operators)
+  - [Booleans](#booleans)
+  - [Enumerations](#enumerations)
+  - [Internal Tables](#internal-tables)
+    - [Count table lines](#count-table-lines)
+    - [Check existence of a table line](#check-existence-of-a-table-line)
+    - [Access table key with uncertain result](#access-table-key-with-uncertain-result)
+    - [Access table index](#access-table-index)
+  - [Conditions](#conditions)
+    - [Conditional distinction](#conditional-distinction)
+    - [Case distinction](#case-distinction)
+    - [Case distinctions of reference types class and interface](#case-distinctions-of-reference-types-class-and-interface)
+  - [Conversions](#conversions)
+    - [Cast data references](#cast-data-references)
+    - [Create data references](#create-data-references)
+    - [Convert data types](#convert-data-types)
+    - [Copy fields with matching names](#copy-fields-with-matching-names)
+  - [Constructors](#constructors)
+    - [Construct objects and data](#construct-objects-and-data)
+    - [Construct data types](#construct-data-types)
+    - [Filter tables](#filter-tables)
+  - [Character Handling](#character-handling)
+    - [Lower and upper case conversion](#lower-and-upper-case-conversion)
+- [Flow control](#flow-control)
+  - [Loop with control break](#loop-with-control-break)
+- [Interface implementation](#interface-implementation)
+  - [Behavior on not implemented interface methods](#behavior-on-not-implemented-interface-methods)
+  - [Partially implement interfaces in tests](#partially-implement-interfaces-in-tests)
+
+## Functional statements and expressions in ABAP
+
+Functional statements and expressions
+have the advantage that they follow the principle of an assignment,
+meaning the result is returned as a returning parameter,
+thus can be directly used in assignments and can be chained.
+
+Data type information in functional statements
+can be abbreviated by a `#`
+if the compiler can determine the data type from the context.
+
+> **Caution**: Some of the functional statements
+> are very powerful and versatile in their usage.
+> When using them, always keep the clean code principles in mind.
+
+### Inline declaration of variables
+
+Use the operators `data` and `field-symbol`
+to combine the declaration and initial value assignment
+of a variable or field symbol.
+
+Allowed at write positions
+for which a type can be determined
+statically from the context.
+This _inferred_ type is given to the declared symbol.
+
+```ABAP
+DATA(text) = `This is a string`.
+
+" old style
+DATA text TYPE string.
+text = `This is a string`.
+```
+
+```ABAP
+DATA(result) = method_with_returning( ).
+
+" old style
+DATA result TYPE accounts_table.
+result = method_with_returning( ).
+```
+
+```ABAP
+method_with_exporting( IMPORTING parameter = DATA(accounts) ).
+
+" old style
+DATA accounts TYPE accounts_table.
+method_with_exporting( IMPORTING parameter = accounts ).
+```
+
+```ABAP
+LOOP AT accounts INTO DATA (acount).
+ENDLOOP.
+
+" old style
+DATA account TYPE accounts_table.
+LOOP AT accounts INTO acount.
+ENDLOOP.
+```
+
+```ABAP
+READ TABLE accounts INTO DATA(acount_sap) WITH KEY id = 5.
+
+" old style
+DATA account_sap TYPE account_structure.
+READ TABLE account INTO data(acount_sap) WITH u id = 5.
+```
+
+```ABAP
+LOOP AT accounts ASSIGNING FIELD-SYMBOL(<account>).
+ENDLOOP.
+
+" old style
+FIELD-SYMBOL <account> TYPE account_structure.
+LOOP AT accounts ASSIGNING (<account>.
+ENDLOOP.
+```
+
+```ABAP
+ASSIGN COMPONENT id OF acount_sap TO FIELD-SYMBOL(<account_id>).
+
+" old style
+FIELD-SYMBOL <account_id> TYPE account_structure.
+ASSIGN COMPONENT id OF acount_sap TO <account_id>.
+```
+
+```ABAP
+SELECT * FROM t000 INTO TABLE @DATA(clients).
+
+" old style
+DATA clients TYPE STANDARD TABLE OF t000.
+SELECT * FROM t000 INTO TABLE clients.
+```
+### Compound Assignment Operators
+Shorthand versions of arithmetic assignments and string concatenation.
+These assignments also allow expressions in the operand position.
+
+| Name | Shorthand operator  | Meaning  |
+|---|---|---|
+| Addition assignment  | x += 1.  | x = x + 1.  |
+| Substraction assignment  | x -= 1.  | x = x - 1.  |
+| Multiplication assignment | x *= 1.  | x = x * 1.  |
+| Division assignment  | x /= 1.  | x = x / 1.  |
+| String assignment | x &&= \|abc\|. | x = x && \|abc\|. |
+
+### Booleans
+
+Comparison with the type `abap_bool` can be omitted in conditions.
+
+```ABAP
+if method_returns_abap_bool( ).
+  "method returned abap_true
+else.
+  "method returned abap_false
+endif.
+```
+
+### Enumerations
+
+Define enumerations instead of using constants.
+
+```ABAP
+types: begin of enum scrum_status_type,
+         open,
+         in_progress,
+         blocked,
+         done,
+       end of enum scrum_status_type.
+
+data(scrum_status) = open.
+```
+
+Old style:
+
+```ABAP
+constants scrum_status_open       type i value 1.
+constants scrum_status_in_process type i value 2.
+constants scrum_status_blocked    type i value 3.
+constants scrum_status_done       type i value 4.
+data scrum status type i.
+
+scrum_status = scrum_status_open.
+```
+
+### Internal Tables
+
+#### Count table lines
+
+Count the number of lines of an internal table use  the function `lines( )`.
+
+```ABAP
+data(number_of_lines) = lines( accounts ).
+```
+
+Old style:
+
+```ABAP
+data number_of_lines type i.
+describe table accounts lines number_of_lines.
+```
+
+#### Check existence of a table line
+
+Check the existence of a line in an internal table, use the function `line_exists( )` within an if-clause.
+
+```ABAP
+if line_exists( accounts[ id = 4711 ] ).
+  "line has been found
+endif.
+```
+
+Old style:
+
+```ABAP
+read table accounts with key id = 4711 transporting no fields.
+if sy-subrc = 0.
+  "line has been found
+endif.
+```
+
+#### Access table key with uncertain result
+
+```ABAP
+data(account) = value #( accounts[ id = '4711' ] optional ).
+```
+
+By default, failing functional key accesses throw an exception. The addition `value ... optional` suppresses this.
+
+Old style:
+
+```ABAP
+try.
+    account = accounts[ id = '4711' ]
+  catch cx_sy_itab_line_not_found.
+endtry.
+```
+
+#### Access table index
+
+Access a specific index of an internal table directly, use the bracket notation `table_name[ ]`.
+
+```ABAP
+data(id_of_account_5) = accounts[ 5 ]-id.
+```
+
+Old style:
+
+```ABAP
+read table accounts index 5 into data(account_5).
+if sy-subrc = 0.
+  data(id_of_account_5) = account_5-id.
+endif.
+```
+
+### Conditions
+
+#### Conditional distinction
+
+To evaluate conditions, use the `cond #( )` operator.
+
+```ABAP
+data(value) = cond #( when status = open then 1
+                      when status = blocked then 3
+                      else 7 ).
+```
+
+Old style:
+
+```ABAP
+data value type i.
+if status = open.
+  value = 1.
+elseif status = blocked.
+  value = 3.
+else.
+  value = 7.
+endif.
+```
+
+> Alternatively you may use the function `xsdbool( )` described [here](readme.md#use-xsdbool-to-set-boolean-variables)
+
+#### Case distinction
+
+Evaluate case distinction with the `switch #( )` operator
+
+```ABAP
+data(status) = switch #( scrum_status
+                         when scrum_status_open then status_waiting
+                         when scrum_status_in_process then status_busy
+                         when scrum_status_blocked then status_alarm
+                   when scrum_status_done then status_ok ).
+```
+
+Old style:
+
+```ABAP
+data status type status_enum.
+case scrum_status.
+  when scrum_status_open.
+    status = status_waiting.
+  when scrum_status_in_process.
+    status = status_busy.
+  when scrum_status_blocked.
+    status = status_alarm.
+  when scrum_status_done.
+    status = status_ok.
+endcase.
+```
+
+#### Case distinctions of reference types class and interface
+
+Switch on a reference types class and interface using the `case` extension `type of`.
+
+```ABAP
+case type of account.
+  when type bank_account into data(bank_account).
+    " some processing ...
+  when others.
+    " some processing ...
+endcase.
+```
+
+In a condition e.g. in an `if` statement the `is instance of` operator can be used.
+
+```ABAP
+if account is instance of bank_account.
+  " some processing ...
+endif.
+```
+
+### Conversions
+
+#### Cast data references
+
+Cast reference types to other reference types use the `cast #( )` operator.
+
+```ABAP
+data(my_account) = cast account( NEW bank_account( ) ).
+```
+
+Old style:
+
+```ABAP
+data my_account type ref to account.
+create object my_account type bank_account.
+```
+
+or
+
+```ABAP
+data my_account type ref to account.
+data my_bank_account type ref to bank_account.
+create object my_bank_account.
+my_account ?= bank_account.
+```
+
+#### Create data references
+
+Create data references to structures and tables with the operator `ref #( )`.
+
+```ABAP
+data accounts type accounts_table.
+import_accounts_references( ref #( accounts ) ).
+```
+
+Old style:
+
+```ABAP
+data accounts type accounts_table.
+data accounts_reference type ref to accounts_type.
+get reference of accounts into accounts_reference.
+import_accounts_references( accounts_reference ) ).
+```
+
+#### Convert data types
+
+Use the operator `conv #( )` to convert data types and save temporary variables.
+
+```ABAP
+method_takes_string( conv #( a_char ) ).
+```
+
+Old style:
+
+```ABAP
+data a_string type string.
+a_string = a_char.
+method_takes_string( a_string ).
+```
+
+#### Copy fields with matching names
+
+Copy fields with matching names from one data type to another with `corresponding #( )`.
+
+```ABAP
+target_structure = corresponding #( source_structure ).
+```
+
+Old style:
+
+```ABAP
+move-corresponding source_structure to target_structure.
+```
+
+### Constructors
+
+#### Construct objects and data
+
+Construct objects and data with the `new #( )` operator.
+
+```ABAP
+data(acount) = new cl_account( ).
+
+data(dref) = new struct_type( component_1 = 10
+                              component_2 = 'a' ).
+```
+
+```ABAP
+data(account) = cast if_account( new cl_account( ) ).
+
+data data_structure TYPE REF TO struct_type.
+create data data_structure.
+data_reference->component_1 = 10.
+data_reference->component_2 = 'a'.
+```
+
+Old style:
+
+```ABAP
+data account type ref to cl_account.
+create object account.
+```
+
+```ABAP
+data account type ref to if_account.
+create object account type cl_account.
+```
+
+#### Construct data types
+
+Construct structures and tables using the `value #( )` operator. It also constructs initial values for most data types.
+
+> This statement is a life saver when writing ABAP unit tests.
+
+Structure:
+
+```ABAP
+data(account) = value account_structure( id = 5
+                                         name = 'SAP' ).
+```
+
+Old style:
+
+```ABAP
+data account type account_structure.
+account-id = 5.
+account-name = 'SAP'.
+```
+
+Table:
+
+```ABAP
+data(accounts) = value accounts_table( ( id = 5  name = 'SAP' )
+                                       ( id = 6  name = 'ABCDE' ) ).
+```
+
+Old style:
+
+```ABAP
+data accounts type accounts_table.
+data account type account_structure.
+account-id = 5.
+account-name = 'SAP'.
+insert account into table accounts.
+account-id = 6.
+account-name = 'ABCDE'.
+insert account into table accounts.
+```
+
+Construct tables based on other tables:
+
+```ABAP
+result = value #( for row in input ( row-text ) ).
+```
+
+Old style:
+
+```ABAP
+loop at input into data(row).
+  insert row-text into table result.
+ENDLOOP.
+```
+
+#### Filter tables
+
+Construct a table as a subset of another stable using `filter #( )`.
+
+```ABAP
+bank_accounts = filter #( accounts
+                          where account_type = 'B' ).
+```
+
+Old style:
+
+```ABAP
+data bank_account type bank_account.
+loop at accounts into bank_account where account_type = 'B'.
+  insert bank_account into table bank_accounts.
+endloop.
+```
+
+### Character Handling
+
+#### Lower and upper case conversion
+
+Convert characters between cases using `to_upper( )` or `to_lower( )`.
+
+```ABAP
+data(uppercase) = to_upper( lowercase ).
+data(lowercase) = to_lower( uppercase ).
+```
+
+Old style:
+
+```ABAP
+translate lowercase to upper case.
+```
+
+## Flow control
+
+### Loop with control break
+
+Process data on defined groups using the new features with the `loop` statement extension `group by ...` and `loop at group`.
+
+```ABAP
+loop at accounts into data(account) group by grouping_id.
+  " once per group before group ...
+  loop at group account into data(account_group).
+    " for each group member ...
+  endloop.
+  " once per group after group ...
+endloop.
+```
+
+Old style:
+
+```ABAP
+data previous_grouping_id type i.
+data last_account type account.
+loop at accounts into data(account).
+  if account-grouping_id <> previous_grouping_id.
+    previous_grouping_id = account-grouping_id
+    " once per group before group ...
+    if last_account is not initial.
+      " once per group after group ...
+    endif.
+  endif.
+  " for each group member ...
+  last_account = account.
+endloop.
+if last_account is not initial.
+  " once per group after group
+endif.
+```
+
+## Interface implementation
+
+### Behavior on not implemented interface methods
+
+Define the effect on not implemented interface methods.
+
+Add `default ignore` to advise ABAP to handle the call to this method if not implemented as a call to an empty implementation.
+
+```ABAP
+interface account.
+  methods new_method default ignore.
+endinterface.
+```
+
+Add `default fail` to advise ABAP to raise an exception `CX_SY_DYN_CALL_ILLEGAL_METHOD` if the not implemented method is called. This is the default behavior.
+
+```ABAP
+interface account.
+  methods new_method default fail.
+endinterface.
+```
+
+### Partially implement interfaces in tests
+
+Implement in tests for e.g. test doubles only the interface methods which you need and skip the not needed with the `partially implemented` extension of the `interfaces` statement.
+
+```ABAP
+interface account.
+  methods add_account importing account type account.
+  methods delete_account importing account_id type account_id.
+  methods get_account importing account_id type account_id
+                      returning value(result) type account.
+endinterface.
+
+class test_double definition for testing.
+  public section.
+  interfaces account partially implemented.
+  data account_stub type account.
+endclass.
+
+class test_double implementation.
+  method productive~get.
+    result = account_stub.
+  endmethod.
+endclass.
+```

--- a/clean-abap/sub-sections/ModernABAP.md
+++ b/clean-abap/sub-sections/ModernABAP.md
@@ -162,13 +162,13 @@ This can, for example, be used to shorten Boolean comparisons:
 IF is_valid( ).
   " method returned abap_true
 ELSE.
-  " method returned abap_false = IS INITIAL
+  " method returned abap_false
 ENDIF.
 ```
 
 ## Enumerations
 
-Define enumerations instead of using constants.
+Define [enumerations](#https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abaptypes_enum.htm#!ABAP_ADDITION_1@1@) instead of using constants.
 
 ```ABAP
 TYPES:
@@ -188,9 +188,9 @@ Old style:
 CONSTANTS scrum_status_open       TYPE i VALUE 1.
 CONSTANTS scrum_status_in_process TYPE i VALUE 2.
 CONSTANTS scrum_status_blocked    TYPE i VALUE 3.
-CONSTANTS scrum_status_done       TYPE i u 4.
-DATA scrum status TYPE i.
+CONSTANTS scrum_status_done       TYPE i VALUE 4.
 
+DATA scrum status TYPE i.
 scrum_status = scrum_status_open.
 ```
 
@@ -198,7 +198,8 @@ scrum_status = scrum_status_open.
 
 ### Count lines
 
-Count the number of lines of an internal table with [`lines( )`](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abendescriptive_functions_table.htm).
+Count the number of lines of an internal table with
+[`lines( )`](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abendescriptive_functions_table.htm).
 
 ```ABAP
 DATA(number_of_lines) = lines( accounts ).
@@ -211,9 +212,10 @@ DATA number_of_lines TYPE i.
 DESCRIBE TABLE accounts LINES number_of_lines.
 ```
 
-#### Check existence of a table line
+### Check existence of a table line
 
-Check the existence of a line in an internal table, use the function `line_exists( )` within an if-clause.
+Check the existence of a line in an internal table,
+use the function `line_exists( )` within an if-clause.
 
 ```ABAP
 if line_exists( accounts[ id = 4711 ] ).

--- a/clean-abap/sub-sections/ModernABAP.md
+++ b/clean-abap/sub-sections/ModernABAP.md
@@ -218,35 +218,36 @@ Check the existence of a line in an internal table,
 use the function `line_exists( )` within an if-clause.
 
 ```ABAP
-if line_exists( accounts[ id = 4711 ] ).
+IF line_exists( accounts[ id = 4711 ] ).
   "line has been found
-endif.
+ENDIF.
 ```
 
 Old style:
 
 ```ABAP
-read table accounts with key id = 4711 transporting no fields.
-if sy-subrc = 0.
+READ TABLE accounts WITH KEY id = 4711 TRANSPORTING NO FIELDS.
+IF sy-subrc = 0.
   "line has been found
-endif.
+ENDIF.
 ```
 
 #### Access table key with uncertain result
 
 ```ABAP
-data(account) = value #( accounts[ id = '4711' ] optional ).
+DATA(account) = VALUE #( accounts[ id = '4711' ] OPTIONAL ).
 ```
 
-By default, failing functional key accesses throw an exception. The addition `value ... optional` suppresses this.
+By default, failing functional key accesses throw an exception.
+The addition `VALUE ... OPTIONAL` suppresses this.
 
 Old style:
 
 ```ABAP
-try.
+TRY.
     account = accounts[ id = '4711' ]
-  catch cx_sy_itab_line_not_found.
-endtry.
+  CATCH cx_sy_itab_line_not_found.
+ENDTRY.
 ```
 
 #### Access table index
@@ -254,150 +255,150 @@ endtry.
 Access a specific index of an internal table directly, use the bracket notation `table_name[ ]`.
 
 ```ABAP
-data(id_of_account_5) = accounts[ 5 ]-id.
+DATA(id_of_account_5) = accounts[ 5 ]-id.
 ```
 
 Old style:
 
 ```ABAP
-read table accounts index 5 into data(account_5).
-if sy-subrc = 0.
-  data(id_of_account_5) = account_5-id.
-endif.
+READ TABLE accounts INDEX 5 INTO DATA(account_5).
+IF sy-subrc = 0.
+  DATA(id_of_account_5) = account_5-id.
+ENDIF.
 ```
 
 ### Conditions
 
 #### Conditional distinction
 
-To evaluate conditions, use the `cond #( )` operator.
+To evaluate conditions, use the `COND #( )` operator.
 
 ```ABAP
-data(value) = cond #( when status = open then 1
-                      when status = blocked then 3
-                      else 7 ).
+DATA(value) = COND #( WHEN status = open THEN 1
+                      WHEN status = blocked THEN 3
+                      ELSE 7 ).
 ```
 
 Old style:
 
 ```ABAP
-data value type i.
-if status = open.
+DATA value TYPE i.
+IF status = open.
   value = 1.
-elseif status = blocked.
+ELSEIF status = blocked.
   value = 3.
-else.
+ELSE.
   value = 7.
-endif.
+ENDIF.
 ```
 
-> Alternatively you may use the function `xsdbool( )` described [here](readme.md#use-xsdbool-to-set-boolean-variables)
+> Alternatively you may use the [function `xsdbool( )`](readme.md#use-xsdbool-to-set-boolean-variables)
 
 #### Case distinction
 
-Evaluate case distinction with the `switch #( )` operator
+Evaluate case distinction with the `SWITCH #( )` operator
 
 ```ABAP
-data(status) = switch #( scrum_status
-                         when scrum_status_open then status_waiting
-                         when scrum_status_in_process then status_busy
-                         when scrum_status_blocked then status_alarm
-                   when scrum_status_done then status_ok ).
+DATA(status) = SWITCH #( scrum_status
+    WHEN scrum_status_open THEN status_waiting
+    WHEN scrum_status_in_process THEN status_busy
+    WHEN scrum_status_blocked THEN status_alarm
+    WHEN scrum_status_done THEN status_ok ).
 ```
 
 Old style:
 
 ```ABAP
-data status type status_enum.
-case scrum_status.
-  when scrum_status_open.
+DATA status TYPE status_enum.
+CASE scrum_status.
+  WHEN scrum_status_open.
     status = status_waiting.
-  when scrum_status_in_process.
+  WHEN scrum_status_in_process.
     status = status_busy.
-  when scrum_status_blocked.
+  WHEN scrum_status_blocked.
     status = status_alarm.
-  when scrum_status_done.
+  WHEN scrum_status_done.
     status = status_ok.
-endcase.
+ENDCASE.
 ```
 
 #### Case distinctions of reference types class and interface
 
-Switch on a reference types class and interface using the `case` extension `type of`.
+Switch on a reference types class and interface using the `CASE` extension `TYPE OF`.
 
 ```ABAP
-case type of account.
-  when type bank_account into data(bank_account).
+CASE type of account.
+  WHEN TYPE bank_account INTO DATA(bank_account).
     " some processing ...
-  when others.
+  WHEN OTHERS.
     " some processing ...
-endcase.
+ENDCASE.
 ```
 
-In a condition e.g. in an `if` statement the `is instance of` operator can be used.
+In a condition e.g. in an `IF` statement the `IS INSTANCE OF` operator can be used.
 
 ```ABAP
-if account is instance of bank_account.
+IF account IS INSTANCE OF bank_account.
   " some processing ...
-endif.
+ENDIF.
 ```
 
 ### Conversions
 
 #### Cast data references
 
-Cast reference types to other reference types use the `cast #( )` operator.
+Cast reference types to other reference types use the `CAST #( )` operator.
 
 ```ABAP
-data(my_account) = cast account( NEW bank_account( ) ).
+DATA(my_account) = CAST account( NEW bank_account( ) ).
 ```
 
 Old style:
 
 ```ABAP
-data my_account type ref to account.
-create object my_account type bank_account.
+DATA my_account TYPE REF TO account.
+CREATE OBJECT my_account TYPE bank_account.
 ```
 
 or
 
 ```ABAP
-data my_account type ref to account.
-data my_bank_account type ref to bank_account.
-create object my_bank_account.
+DATA my_account TYPE REF TO account.
+DATA my_bank_account TYPE REF TO bank_account.
+CREATE OBJECT my_bank_account.
 my_account ?= bank_account.
 ```
 
 #### Create data references
 
-Create data references to structures and tables with the operator `ref #( )`.
+Create data references to structures and tables with the operator `REF #( )`.
 
 ```ABAP
-data accounts type accounts_table.
-import_accounts_references( ref #( accounts ) ).
+DATA accounts TYPE accounts_table.
+import_accounts_references( REF #( accounts ) ).
 ```
 
 Old style:
 
 ```ABAP
-data accounts type accounts_table.
-data accounts_reference type ref to accounts_type.
-get reference of accounts into accounts_reference.
+DATA accounts TYPE accounts_table.
+DATA accounts_reference TYPE REF TO accounts_type.
+GET REFERENCE OF accounts INTO accounts_reference.
 import_accounts_references( accounts_reference ) ).
 ```
 
 #### Convert data types
 
-Use the operator `conv #( )` to convert data types and save temporary variables.
+Use the operator `CONV #( )` to convert data types and save temporary variables.
 
 ```ABAP
-method_takes_string( conv #( a_char ) ).
+method_takes_string( CONV #( a_char ) ).
 ```
 
 Old style:
 
 ```ABAP
-data a_string type string.
+DATA a_string TYPE string.
 a_string = a_char.
 method_takes_string( a_string ).
 ```
@@ -407,33 +408,35 @@ method_takes_string( a_string ).
 Copy fields with matching names from one data type to another with `corresponding #( )`.
 
 ```ABAP
-target_structure = corresponding #( source_structure ).
+target_structure = CORRESPONDING #( source_structure ).
 ```
 
 Old style:
 
 ```ABAP
-move-corresponding source_structure to target_structure.
+MOVE-CORRESPONDING source_structure TO target_structure.
 ```
+
+> The two differ slightly in behavior.
 
 ### Constructors
 
 #### Construct objects and data
 
-Construct objects and data with the `new #( )` operator.
+Construct objects and data with the `NEW #( )` operator.
 
 ```ABAP
-data(acount) = new cl_account( ).
+DATA(acount) = NEW cl_account( ).
 
-data(dref) = new struct_type( component_1 = 10
+DATA(dref) = NEW struct_type( component_1 = 10
                               component_2 = 'a' ).
 ```
 
 ```ABAP
-data(account) = cast if_account( new cl_account( ) ).
+DATA(account) = CAST if_account( NEW cl_account( ) ).
 
-data data_structure TYPE REF TO struct_type.
-create data data_structure.
+DATA data_structure TYPE REF TO struct_type.
+CREATE DATA data_structure.
 data_reference->component_1 = 10.
 data_reference->component_2 = 'a'.
 ```
@@ -441,32 +444,33 @@ data_reference->component_2 = 'a'.
 Old style:
 
 ```ABAP
-data account type ref to cl_account.
-create object account.
+DATA account TYPE REF TO cl_account.
+CREATE OBJECT account.
 ```
 
 ```ABAP
-data account type ref to if_account.
-create object account type cl_account.
+DATA account TYPE REF TO if_account.
+CREATE OBJECT account TYPE cl_account.
 ```
 
 #### Construct data types
 
-Construct structures and tables using the `value #( )` operator. It also constructs initial values for most data types.
+Construct structures and tables using the `VALUE #( )` operator.
+It also constructs initial values for most data types.
 
 > This statement is a life saver when writing ABAP unit tests.
 
 Structure:
 
 ```ABAP
-data(account) = value account_structure( id = 5
+DATA(account) = VALUE account_structure( id = 5
                                          name = 'SAP' ).
 ```
 
 Old style:
 
 ```ABAP
-data account type account_structure.
+DATA account TYPE account_structure.
 account-id = 5.
 account-name = 'SAP'.
 ```
@@ -474,53 +478,53 @@ account-name = 'SAP'.
 Table:
 
 ```ABAP
-data(accounts) = value accounts_table( ( id = 5  name = 'SAP' )
+DATA(accounts) = VALUE accounts_table( ( id = 5  name = 'SAP' )
                                        ( id = 6  name = 'ABCDE' ) ).
 ```
 
 Old style:
 
 ```ABAP
-data accounts type accounts_table.
-data account type account_structure.
+DATA accounts TYPE accounts_table.
+DATA account TYPE account_structure.
 account-id = 5.
 account-name = 'SAP'.
-insert account into table accounts.
+INSERT account INTO TABLE accounts.
 account-id = 6.
 account-name = 'ABCDE'.
-insert account into table accounts.
+INSERT ACCOUNT INTO TABLE accounts.
 ```
 
 Construct tables based on other tables:
 
 ```ABAP
-result = value #( for row in input ( row-text ) ).
+result = VALUE #( FOR row IN input ( row-text ) ).
 ```
 
 Old style:
 
 ```ABAP
-loop at input into data(row).
-  insert row-text into table result.
+LOOP AT input INTO DATA(row).
+  INSERT row-text INTO TABLE result.
 ENDLOOP.
 ```
 
 #### Filter tables
 
-Construct a table as a subset of another stable using `filter #( )`.
+Construct a table as a subset of another stable using `FILTER #( )`.
 
 ```ABAP
-bank_accounts = filter #( accounts
-                          where account_type = 'B' ).
+bank_accounts = FILTER #( accounts
+                          WHERE account_type = 'B' ).
 ```
 
 Old style:
 
 ```ABAP
-data bank_account type bank_account.
-loop at accounts into bank_account where account_type = 'B'.
-  insert bank_account into table bank_accounts.
-endloop.
+DATA bank_account TYPE bank_account.
+LOOP AT accounts INTO bank_account WHERE account_type = 'B'.
+  INSERT bank_account INTO TABLE bank_accounts.
+ENDLOOP.
 ```
 
 ### Character Handling
@@ -530,14 +534,14 @@ endloop.
 Convert characters between cases using `to_upper( )` or `to_lower( )`.
 
 ```ABAP
-data(uppercase) = to_upper( lowercase ).
-data(lowercase) = to_lower( uppercase ).
+DATA(uppercase) = to_upper( lowercase ).
+DATA(lowercase) = to_lower( uppercase ).
 ```
 
 Old style:
 
 ```ABAP
-translate lowercase to upper case.
+TRANSLATE lowercase TO UPPER CASE.
 ```
 
 ## Flow control
@@ -547,34 +551,34 @@ translate lowercase to upper case.
 Process data on defined groups using the new features with the `loop` statement extension `group by ...` and `loop at group`.
 
 ```ABAP
-loop at accounts into data(account) group by grouping_id.
+LOOP AT accounts INTO DATA(account) GROUP BY grouping_id.
   " once per group before group ...
-  loop at group account into data(account_group).
+  LOOP AT GROUP account INTO DATA(account_group).
     " for each group member ...
-  endloop.
+  ENDLOOP.
   " once per group after group ...
-endloop.
+ENDLOOP.
 ```
 
 Old style:
 
 ```ABAP
-data previous_grouping_id type i.
-data last_account type account.
-loop at accounts into data(account).
-  if account-grouping_id <> previous_grouping_id.
+DATA previous_grouping_id TYPE i.
+DATA last_account TYPE account.
+LOOP AT accounts INTO data(account).
+  IF account-grouping_id <> previous_grouping_id.
     previous_grouping_id = account-grouping_id
     " once per group before group ...
-    if last_account is not initial.
+    IF last_account IS NOT INITIAL.
       " once per group after group ...
-    endif.
-  endif.
+    ENDIF.
+  ENDIF.
   " for each group member ...
   last_account = account.
-endloop.
-if last_account is not initial.
+ENDLOOP.
+IF last_account IS NOT INITIAL.
   " once per group after group
-endif.
+ENDIF.
 ```
 
 ## Interface implementation
@@ -583,20 +587,20 @@ endif.
 
 Define the effect on not implemented interface methods.
 
-Add `default ignore` to advise ABAP to handle the call to this method if not implemented as a call to an empty implementation.
+Add `DEFAULT IGNORE` to advise ABAP to handle the call to this method if not implemented as a call to an empty implementation.
 
 ```ABAP
-interface account.
-  methods new_method default ignore.
-endinterface.
+INTERFACE account.
+  METHODS new_method DEFAULT IGNORE.
+ENDINTERFACE.
 ```
 
-Add `default fail` to advise ABAP to raise an exception `CX_SY_DYN_CALL_ILLEGAL_METHOD` if the not implemented method is called. This is the default behavior.
+Add `DEFAULT FAIL` to advise ABAP to raise an exception `CX_SY_DYN_CALL_ILLEGAL_METHOD` if the not implemented method is called. This is the default behavior.
 
 ```ABAP
-interface account.
-  methods new_method default fail.
-endinterface.
+INTERFACE account.
+  METHODS new_method default FAIL.
+ENDINTERFACE.
 ```
 
 ### Partially implement interfaces in tests
@@ -604,22 +608,22 @@ endinterface.
 Implement in tests for e.g. test doubles only the interface methods which you need and skip the not needed with the `partially implemented` extension of the `interfaces` statement.
 
 ```ABAP
-interface account.
-  methods add_account importing account type account.
-  methods delete_account importing account_id type account_id.
-  methods get_account importing account_id type account_id
-                      returning value(result) type account.
-endinterface.
+INTERFACE account.
+  METHODS add_account IMPORTING account TYPE account.
+  METHODS delete_account IMPORTING account_id TYPE account_id.
+  METHODS get_account IMPORTING account_id TYPE account_id
+                      RETURNING value(result) TYPE account.
+ENDINTERFACE.
 
-class test_double definition for testing.
-  public section.
-  interfaces account partially implemented.
-  data account_stub type account.
-endclass.
+CLASS test_double DEFINITION FOR TESTING.
+  PUBLIC SECTION.
+  INTERFACES account PARTIALLY IMPLEMENTED.
+  DATA account_stub TYPE account.
+ENDCLASS.
 
-class test_double implementation.
-  method productive~get.
+CLASS test_double IMPLEMENTATION.
+  METHOD productive~get.
     result = account_stub.
-  endmethod.
-endclass.
+  ENDMETHOD.
+ENDCLASS.
 ```

--- a/clean-abap/sub-sections/ModernABAPLanguageElements.md
+++ b/clean-abap/sub-sections/ModernABAPLanguageElements.md
@@ -7,10 +7,10 @@ that improve readability of the code
 and therefore should be in the tool set
 of any professional ABAPer.
 
-The new ABAP statements are not described to full detail.
-For more information please consult the ABAP online documentation.
+The new ABAP statements are only outlined in short;
+refer to the ABAP online documentation for more details.
 
-## Table of Contents
+## Content
 
 - [Functional statements and expressions in ABAP](#functional-statements-and-expressions-in-abap)
 - [Inline declaration of variables](#inline-declaration-of-variables)
@@ -54,9 +54,10 @@ Data type information in functional statements
 can be abbreviated by a `#`
 if the compiler can determine the data type from the context.
 
-> **Caution**: Some of the functional statements
-> are very powerful and versatile in their usage.
-> When using them, always keep the clean code principles in mind.
+> **Keep the clean code principles in mind**
+> when using these statements.
+> They are very compact and powerful and may tempt you to
+> compress your code so much that it becomes unintelligible. 
 
 ## Inline declaration of variables
 

--- a/clean-abap/sub-sections/ModernABAPLanguageElements.md
+++ b/clean-abap/sub-sections/ModernABAPLanguageElements.md
@@ -15,7 +15,7 @@ For more information please consult the ABAP online documentation.
 - [Functional statements and expressions in ABAP](#functional-statements-and-expressions-in-abap)
 - [Inline declaration of variables](#inline-declaration-of-variables)
 - [Compound Assignment Operators](#compound-assignment-operators)
-- [Booleans](#booleans)
+- [Non-Initial Conditions](#non-initial-conditions)
 - [Enumerations](#enumerations)
 - [Internal Tables](#internal-tables)
   - [Count lines](#count-table-lines)
@@ -168,7 +168,7 @@ ENDIF.
 
 ## Enumerations
 
-Define [enumerations](#https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abaptypes_enum.htm#!ABAP_ADDITION_1@1@) instead of using constants.
+Define [enumerations](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abaptypes_enum.htm#!ABAP_ADDITION_1@1@) instead of using constants.
 
 ```ABAP
 TYPES:
@@ -196,7 +196,7 @@ scrum_status = scrum_status_open.
 
 ## Internal Tables
 
-### Count lines
+### Count table lines
 
 Count the number of lines of an internal table with
 [`lines( )`](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/abendescriptive_functions_table.htm).
@@ -292,7 +292,7 @@ ELSE.
 ENDIF.
 ```
 
-> Alternatively you may use the [function `xsdbool( )`](readme.md#use-xsdbool-to-set-boolean-variables)
+> Alternatively you may use the [function `xsdbool( )`](../CleanABAP.md#use-xsdbool-to-set-boolean-variables)
 
 #### Case distinction
 

--- a/clean-abap/sub-sections/ModernABAPLanguageElements.md
+++ b/clean-abap/sub-sections/ModernABAPLanguageElements.md
@@ -98,21 +98,21 @@ method_with_exporting( IMPORTING parameter = accounts ).
 ```
 
 ```ABAP
-LOOP AT accounts INTO DATA (acount).
+LOOP AT accounts INTO DATA (account).
 ENDLOOP.
 
 " old style
-DATA account TYPE accounts_table.
-LOOP AT accounts INTO acount.
+DATA account TYPE account_structure.
+LOOP AT accounts INTO account.
 ENDLOOP.
 ```
 
 ```ABAP
-READ TABLE accounts INTO DATA(acount_sap) WITH KEY id = 5.
+READ TABLE accounts INTO DATA(account_sap) WITH KEY id = 5.
 
 " old style
 DATA account_sap TYPE account_structure.
-READ TABLE account INTO data(acount_sap) WITH u id = 5.
+READ TABLE account INTO data(account_sap) WITH u id = 5.
 ```
 
 ```ABAP
@@ -126,11 +126,11 @@ ENDLOOP.
 ```
 
 ```ABAP
-ASSIGN COMPONENT id OF acount_sap TO FIELD-SYMBOL(<account_id>).
+ASSIGN COMPONENT id OF account_sap TO FIELD-SYMBOL(<account_id>).
 
 " old style
 FIELD-SYMBOL <account_id> TYPE account_id_type.
-ASSIGN COMPONENT id OF acount_sap TO <account_id>.
+ASSIGN COMPONENT id OF account_sap TO <account_id>.
 ```
 
 ```ABAP
@@ -348,7 +348,7 @@ ENDIF.
 
 #### Cast data references
 
-Cast reference types to other reference types use the `CAST #( )` operator.
+Cast reference types to other reference types using the `CAST #( )` operator.
 
 ```ABAP
 DATA(my_account) = CAST account( NEW bank_account( ) ).
@@ -418,7 +418,9 @@ Old style:
 MOVE-CORRESPONDING source_structure TO target_structure.
 ```
 
-> The two differ slightly in behavior.
+> Caution: The two statements differ in behavior.
+> The `CORRESPONDING( )` statement is a constructor statement, meaning all fields in the `target_structure` are initialized before the corresponding `source_structure` values are copied to the `target_sructure`
+> The `MOVE-CORRESPONDING` statement in contrast leaves the content of the not matching fields in the `target_structure untouched.
 
 ### Constructors
 


### PR DESCRIPTION
Renamed the section _Prefer functional to procedural language constructs_ to _Prefer modern language constructs_ and let it link to a new sub-section that lists the most helpful language additions from the past years.

The Modern ABAP page was part of the SAP-internal repository and was only omitted during first release to public because of some questions how to best link it into the larger document.

This should also address the issue https://github.com/SAP/styleguides/issues/18: While there is still a preference towards functional statements, this section also suggests using some other innovations.

> The term "functional" here refers more to the "way of writing the statement", with brackets and returning value, instead of the functional programming paradigm.