### PR TITLE
Clarify RAISE EXCEPTION NEW only from 7.52

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3170,6 +3170,7 @@ Use this only if you are sure about that.
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Error Handling](#error-handling) > [Throwing](#throwing) > [This section](#prefer-raise-exception-new-to-raise-exception-type)
 
+Note: Available from NW 7.52 onwards.
 ```ABAP
 RAISE EXCEPTION NEW cx_generation_error( previous = exception ).
 ```


### PR DESCRIPTION
This didn't work on a 7.50 system. The documentation indicates this was changed in 7.52 where "oref is a general expression position". See:
https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/index.htm?file=abapraise_exception_class.htm
https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/index.htm?file=abapraise_exception_class.htm