### PR TITLE
Adjust message length recommendation

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2695,7 +2695,7 @@ The bullets (s)he numbers are the sub-methods the method should call or the stat
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Method Body](#method-body) > [This section](#keep-methods-small)
 
-Methods should be very small, optimally around 3 to 5 statements.
+Methods should have less than 20 statements, optimal around 3 to 5 statements.
 
 ```ABAP
 METHOD read_and_parse_version_filters.


### PR DESCRIPTION
As many ABAP developers are used to long methods,
the target of 3-5 statements seems so unrealistic
to them, that it creates resistance right away.
Therfore the "20 is ok, but 3-5 as a target is better" change.