### PR TITLE
Use plural only for variables, members etc., maybe not for databases

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -403,6 +403,11 @@ for example `country` for a "table of countries".
 Common tendency in the outside world is to use the plural for lists of things.
 We therefore recommend to prefer `countries` instead.
 
+> This advice primarily targets things like variables and properties.
+> For development objects, there may be competing patterns
+> that also make sense, for example the widely used convention
+> to name database tables ("transparent tables") in singular.
+
 > Read more in _Chapter 2: Meaningful Names: Use Intention-Revealing Names_ of [Robert C. Martin's _Clean Code_].
 
 ### Use pronounceable names


### PR DESCRIPTION
Tiny clarification, brought to attention by an SAP employee. It's not wrong to name database tables in plural, but the fact that they serve as structures at the same time makes it cumbersome.