### PR TITLE
Remove /dirty/ from good example

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -910,7 +910,7 @@ ENDIF.
 
 ```ABAP
 DATA name TYPE seoclsname.
-DATA reader TYPE REF TO /dirty/reader.
+DATA reader TYPE REF TO reader.
 ```
 
 Chaining suggests the defined variables are related on a logical level.
@@ -926,7 +926,7 @@ colons, dots, and commas, that are not worth the effort.
 " anti-pattern
 DATA:
   name   TYPE seoclsname,
-  reader TYPE REF TO /dirty/reader.
+  reader TYPE REF TO reader.
 ```
 
 > Also refer to [Don't align type clauses](#dont-align-type-clauses)  


### PR DESCRIPTION
I'm sure this was unintentional, but having /dirty/ in the positive example is confusing. As the type is not relevant to the point of the example it should be omitted altogether.