### PR TITLE
Fixed indention at "If you break, indent param..."

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3948,8 +3948,8 @@ DATA(sum) = add_two_numbers(
 
 ```ABAP
 DATA(sum) = add_two_numbers(
-                   value_1 = 5
-                   value_2 = 6 ).
+                value_1 = 5
+                value_2 = 6 ).
 ```
 
 Aligning the parameters elsewhere makes it hard to spot what they belong to:


### PR DESCRIPTION
Currently, the clean example at "If you break, indent parameters under the call" contradicts the indention of the 2nd clean example at "Indent and snap to tab". I'm pretty sure the extra spaces at "If you break, indent parameters under the call" shouldn't be there.