### PR TITLE
Fix and improve example

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -842,13 +842,17 @@ CONSTANTS:
 The group also allows you group-wise access, for example for input validation:
 
 ```ABAP
-DO number_of_constants TIMES.
+DO.
   ASSIGN COMPONENT sy-index OF STRUCTURE message_severity TO FIELD-SYMBOL(<constant>).
-  IF <constant> = input.
-    is_valid = abap_true.
+  IF sy-subrc IS INITIAL.
+    IF input = <constant>.
+      DATA(is_valid) = abap_true.
+      RETURN.
+    ENDIF.
+  ELSE.
     RETURN.
   ENDIF.
-ENDWHILE.
+ENDDO.
 ```
 
 > Read more in _Chapter 17: Smells and Heuristics: G27: Structure over Convention_ of [Robert C. Martin's _Clean Code_].


### PR DESCRIPTION
fix #127 

I've spotted an error in the last code example of section "[If you don't use enumeration classes, group your constants](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#if-you-dont-use-enumeration-classes-group-your-constants)", where the closing sentence should be ENDDO instead of ENDWHILE.

However, I'd like to suggest changing this example for the following, correcting the mistake but also not needing to define a variable with the total of possible values (which should be updated every time we add a new one).