### PR TITLE
Adjusted definition of lth_unit_tests

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -4234,9 +4234,7 @@ inheritance (is-a relationship) or delegation (has-a relationship).
 ```abap
 " inheritance example
 
-CLASS lth_unit_tests DEFINITION ABSTRACT FOR TESTING
-  DURATION SHORT
-  RISK LEVEL HARMLESS.
+CLASS lth_unit_tests DEFINITION ABSTRACT.
 
   PROTECTED SECTION.
     CLASS-METHODS assert_activity_entity


### PR DESCRIPTION
It is unnecessary to have "FOR TESTING" in the definition of the help class lth_unit_tests. The actual test methods are in the class ltc_unit_tests.