### PR TITLE
Update CleanABAP.md

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -803,7 +803,7 @@ INTERFACE /dirty/common_constants.
     persisted    TYPE i       VALUE 2.
 ENDINTERFACE.
 ```
-
+Interfaces define a type and can be implemented in a class, this is not meaningful for a constant interface.
 > [Enumerations](sub-sections/Enumerations.md)
 > describes common enumeration patterns
 > and discusses their advantages and disadvantages.

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -792,6 +792,8 @@ ENDCLASS.
 ```
 
 instead of mixing unrelated things
+or misleading people to the conclusion
+that constants collections could be "implemented":
 
 ```ABAP
 " anti-pattern
@@ -803,7 +805,7 @@ INTERFACE /dirty/common_constants.
     persisted    TYPE i       VALUE 2.
 ENDINTERFACE.
 ```
-Interfaces define a type and can be implemented in a class, this is not meaningful for a constant interface.
+
 > [Enumerations](sub-sections/Enumerations.md)
 > describes common enumeration patterns
 > and discusses their advantages and disadvantages.


### PR DESCRIPTION
As constant interface a used quite frequently in ABAP, some frameworks even generate them, I added a sentence why constant interfaces are anti-pattern. Imho. Uncle Bob´s book is not explicitly mentioning this.