### PR TITLE
Change the name of Chinese translation.

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2,7 +2,7 @@
 
 > [**English**](CleanABAP.md)
 > &nbsp;·&nbsp;
-> [文言](CleanABAP_zh.md)
+> [中文](CleanABAP_zh.md)
 > &nbsp;·&nbsp;
 > [Français](CleanABAP_fr.md)
 > &nbsp;·&nbsp;

--- a/clean-abap/CleanABAP_de.md
+++ b/clean-abap/CleanABAP_de.md
@@ -7,7 +7,7 @@
 > &nbsp;·&nbsp;
 > [English](CleanABAP.md)
 > &nbsp;·&nbsp;
-> [文言](CleanABAP_zh.md)
+> [中文](CleanABAP_zh.md)
 > &nbsp;·&nbsp;
 > [Français](CleanABAP_fr.md)
 

--- a/clean-abap/CleanABAP_fr.md
+++ b/clean-abap/CleanABAP_fr.md
@@ -7,7 +7,7 @@
 > &nbsp;·&nbsp;
 > [English](CleanABAP.md)
 > &nbsp;·&nbsp;
-> [文言](CleanABAP_zh.md)
+> [中文](CleanABAP_zh.md)
 > &nbsp;·&nbsp;
 > [Deutsch](CleanABAP_de.md)
 

--- a/clean-abap/CleanABAP_zh.md
+++ b/clean-abap/CleanABAP_zh.md
@@ -3,7 +3,7 @@
 
 # ABAP 整洁之道
 
-> [**文言**](CleanABAP_zh.md)
+> [**中文**](CleanABAP_zh.md)
 > &nbsp;·&nbsp;
 > [English](CleanABAP.md)
 > &nbsp;·&nbsp;


### PR DESCRIPTION
[文言 ](https://en.wikipedia.org/wiki/Classical_Chinese)(Classical Chinese) is a traditional style of written Chinese. The Chinese translation is written in modern Chinese, not in Classical Chinese. [中文](https://en.wikipedia.org/wiki/Written_Chinese) is a common name of written Chinese.