### PR TITLE
Reword incorrect use of "refrain"

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -4475,14 +4475,14 @@ without interfering with the rest of the system.
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Testing](#testing) > [Injection](#injection) > [This section](#use-test-seams-as-temporary-workaround)
 
 If all other techniques fail, or when in dangerous shallow waters of legacy code,
-refrain to [test seams](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/index.htm?file=abaptest-seam.htm)
+you can resort to [test seams](https://help.sap.com/doc/abapdocu_751_index_htm/7.51/en-US/index.htm?file=abaptest-seam.htm)
 to make things testable.
 
 Although they look comfortable at first sight, test seams are invasive and tend to get entangled
 in private dependencies, such that they are hard to keep alive and stable in the long run.
 
-We therefore recommend to refrain to test seams only as a temporary workaround
-to allow you refactoring the code into a more testable form.
+We therefore recommend to refrain from test seams and only use them as a temporary workaround
+to allow you to refactor the code into a more testable form.
 
 #### Use LOCAL FRIENDS to access the dependency-inverting constructor
 


### PR DESCRIPTION
"Refrain to" doesn't make sense in English. "refrain" means to restrain or hold back (In German: unterlassen/zurückhalten).