### PR TITLE
Fix docu for Prefer RAISE EXCEPTION NEW

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3313,9 +3313,9 @@ However, if you make massive use of the addition `MESSAGE`, you may want to stic
 
 ```ABAP
 RAISE EXCEPTION TYPE cx_generation_error
+  MESSAGE e136(messages)
   EXPORTING
-    previous = exception
-  MESSAGE e136(messages).
+    previous = exception.
 ```
 
 ### Catching


### PR DESCRIPTION
```ABAP
RAISE EXCEPTION TYPE cx_generation_error
  EXPORTING
    previous = exception
  MESSAGE e136(messages).
``` 
Old version is syntax error.
In the newest ABAP documentation, the message is before exporting.