### PR TITLE
Use && for splitting long texts to multiple lines and aliases for interface members

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -65,6 +65,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
 - [Strings](#strings)
   - [Use ` to define literals](#use--to-define-literals)
   - [Use | to assemble text](#use--to-assemble-text)
+  - [Use && to split long text](#use--to-split-long-text)
 - [Booleans](#booleans)
   - [Use Booleans wisely](#use-booleans-wisely)
   - [Use ABAP_BOOL for Booleans](#use-abap_bool-for-booleans)
@@ -1223,6 +1224,23 @@ especially if you embed multiple variables in a text.
 ```ABAP
 " anti-pattern
 DATA(message) = `Received an unexpected HTTP ` && status_code && ` with message ` && text.
+```
+
+### Use && to split long text
+
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Strings](#strings) > [This section](#use--to-split-long-text)
+
+```ABAP
+DATA(message) = |This is a really long text having { variable } and characters| && 
+                |exceeding the preferred limit of { character_limit } with message { text }|.
+```
+
+If the text is long and exceeds the preferred limit of 120 characters, the text should be split 
+into multiple lines. However, pipe operator does not allow splitting texts in multiple lines.
+In such scenario, && can be used. Ideally, keep your texts short and crisp avoiding such occurence.
+```ABAP
+" anti-pattern
+DATA(message) = |This is a really long text having { variable } and characters exceeding the preferred limit of { character_limit } with message { text }|.
 ```
 
 ## Booleans

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -111,6 +111,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
   - [Methods: Object orientation](#methods-object-orientation)
     - [Prefer instance to static methods](#prefer-instance-to-static-methods)
     - [Public instance methods should be part of an interface](#public-instance-methods-should-be-part-of-an-interface)
+    - [Use alias for using interface members](#use-alias)
   - [Parameter Number](#parameter-number)
     - [Aim for few IMPORTING parameters, at best less than three](#aim-for-few-importing-parameters-at-best-less-than-three)
     - [Split methods instead of adding OPTIONAL parameters](#split-methods-instead-of-adding-optional-parameters)
@@ -2198,6 +2199,27 @@ which will never have an alternative implementation and will never be mocked in 
 
 > [Interfaces vs. abstract classes](sub-sections/InterfacesVsAbstractClasses.md)
 describes why this also applies to classes that overwrite inherited methods.
+
+#### Use alias for using interface members
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Methods: Object orientation](#methods-object-orientation) > [This section](#use-alias)
+While calling interface methods or using interface attributes, using alias is much cleaner.
+
+```ABAP
+class clean_class definition public inheriting from if_clean_interface.
+private section.
+  aliases result for if_clean_interface~result .
+  aliases input  for if_clean_interface~input  .
+  aliases get_something for if_clean_interface~get_something .
+ ....
+ ```
+```ABAP
+get_something( changing result = input )
+```
+
+" anti-pattern
+```ABAP
+if_clean_interface~get_something( changing if_clean_interface~result = if_clean_interface~input )
+```
 
 ### Parameter Number
 

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2215,7 +2215,6 @@ private section.
   aliases input  for legacy_interface_long_name~input  .
   aliases get_something for legacy_interface_long_name~get_something .
  ....
- ```
 ```ABAP
 get_something( changing result = input )
 ```

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -111,7 +111,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
   - [Methods: Object orientation](#methods-object-orientation)
     - [Prefer instance to static methods](#prefer-instance-to-static-methods)
     - [Public instance methods should be part of an interface](#public-instance-methods-should-be-part-of-an-interface)
-    - [Use alias for using interface members](#use-alias)
+    - [Use alias for using interface members](#use-alias-for-using-interface-members)
   - [Parameter Number](#parameter-number)
     - [Aim for few IMPORTING parameters, at best less than three](#aim-for-few-importing-parameters-at-best-less-than-three)
     - [Split methods instead of adding OPTIONAL parameters](#split-methods-instead-of-adding-optional-parameters)
@@ -2200,18 +2200,20 @@ which will never have an alternative implementation and will never be mocked in 
 > [Interfaces vs. abstract classes](sub-sections/InterfacesVsAbstractClasses.md)
 describes why this also applies to classes that overwrite inherited methods.
 
-#### Use alias for using interface members
+#### Use alias for using interface members 
 
-> [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Methods: Object orientation](#methods-object-orientation) > [This section](#use-alias)
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Methods: Object orientation](#methods-object-orientation) > [This section](#use-alias-for-using-interface-members)
 
-While calling interface methods or using interface attributes, using alias is much cleaner.
+While calling interface methods or using interface attributes, if the interface name is long, using alias is cleaner.
 
 ```ABAP
-class clean_class definition public inheriting from if_clean_interface.
+class clean_class definition ...
+public section.
+  interfaces legacy_interface_long_name.
 private section.
-  aliases result for if_clean_interface~result .
-  aliases input  for if_clean_interface~input  .
-  aliases get_something for if_clean_interface~get_something .
+  aliases result for legacy_interface_long_name~result .
+  aliases input  for legacy_interface_long_name~input  .
+  aliases get_something for legacy_interface_long_name~get_something .
  ....
  ```
 ```ABAP
@@ -2220,9 +2222,8 @@ get_something( changing result = input )
 
 ```ABAP
 " anti-pattern
-if_clean_interface~get_something( changing if_clean_interface~result = if_clean_interface~input )
+legacy_interface_long_name~get_something( changing result = legacy_interface_long_name~input )
 ```
-
 ### Parameter Number
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [This section](#parameter-number)

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2201,7 +2201,9 @@ which will never have an alternative implementation and will never be mocked in 
 describes why this also applies to classes that overwrite inherited methods.
 
 #### Use alias for using interface members
+
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Methods: Object orientation](#methods-object-orientation) > [This section](#use-alias)
+
 While calling interface methods or using interface attributes, using alias is much cleaner.
 
 ```ABAP
@@ -2216,8 +2218,8 @@ private section.
 get_something( changing result = input )
 ```
 
-" anti-pattern
 ```ABAP
+" anti-pattern
 if_clean_interface~get_something( changing if_clean_interface~result = if_clean_interface~input )
 ```
 


### PR DESCRIPTION
Updated as per comments in the previous pull request. 