### PR TITLE
[Clean ABAP] Static method calls

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -102,6 +102,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
     - [Make singletons only where multiple instances don't make sense](#make-singletons-only-where-multiple-instances-dont-make-sense)
 - [Methods](#methods)
   - [Calls](#calls)
+    - [Don't call static methods through instance variables](#dont-call-static-methods-through-instance-variables)
     - [Prefer functional to procedural calls](#prefer-functional-to-procedural-calls)
     - [Omit RECEIVING](#omit-receiving)
     - [Omit the optional keyword EXPORTING](#omit-the-optional-keyword-exporting)
@@ -2021,6 +2022,45 @@ These rules apply to methods in classes and function modules.
 ### Calls
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [This section](#calls)
+
+#### Don't call static methods through instance variables
+
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Methods](#methods) > [Calls](#calls) > [This section](#dont-call-static-methods-through-instance-variables)
+
+For calling a static method, use
+```ABAP
+cl_my_class=>static_method( ).
+```
+
+Instead of calling it through an instance variable to `cl_my_class`
+```ABAP
+" anti-pattern
+lo_my_instance->static_method( ).
+```
+
+A static method is attached to the class itself, and calling it through an instance variable is a potential source of confusion.
+
+It's OK to call a static method of the same class without qualifying it within another static method.
+
+```ABAP
+METHOD static_method.
+  another_static_method( ).
+  yet_another( ).
+ENDMETHOD.
+```
+
+However, within an instance method, even when calling a static method of the same class, you should still qualify the call with the class name:
+
+```ABAP
+CLASS cl_my_class IMPLEMENTATION.
+
+  METHOD instance_method.
+    cl_my_class=>a_static_method( ).
+    another_instance_method( ).
+  ENDMETHOD.
+
+  ...
+```
 
 #### Prefer functional to procedural calls
 


### PR DESCRIPTION
Clarify calling of static methods.

Resolves SAP/styleguides#210