### PR TITLE
linguist: detect adoc and md files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.adoc linguist-detectable
+*.md linguist-detectable


### PR DESCRIPTION
Currently linguist detects the stuleguides repo as CSS,
![image](https://user-images.githubusercontent.com/5888506/134659232-8683c93c-fd07-429f-ae5c-031175d70fa2.png)
Linguist detects only programming languages, not documentation, to take documentation into account it must be overridden
https://github.com/github/linguist/blob/master/docs/overrides.md