### PR TITLE
docs: Remove IF block in CHECK vs. RETURN

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3002,17 +3002,6 @@ METHOD read_customizing.
 ENDMETHOD.
 ```
 
-You can avoid the question completely by reversing the validation
-and adopting a single-return control flow
-
-```ABAP
-METHOD read_customizing.
-  IF keys IS NOT INITIAL.
-    " do whatever needs doing
-  ENDIF.
-ENDMETHOD.
-```
-
 In any case, consider whether returning nothing is really the appropriate behavior.
 Methods should provide a meaningful result, meaning either a filled return parameter, or an exception.
 Returning nothing is in many cases similar to returning `null`, which should be avoided.

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3002,6 +3002,18 @@ METHOD read_customizing.
 ENDMETHOD.
 ```
 
+You could avoid the question completely by reversing the validation and adopting a single-return control flow.
+This is considered to be an anti-pattern because it introduces unnecessary nesting depth.
+
+```ABAP
+METHOD read_customizing.
+  " anti-pattern
+  IF keys IS NOT INITIAL.
+    " do whatever needs doing
+  ENDIF.
+ENDMETHOD.
+```
+
 In any case, consider whether returning nothing is really the appropriate behavior.
 Methods should provide a meaningful result, meaning either a filled return parameter, or an exception.
 Returning nothing is in many cases similar to returning `null`, which should be avoided.


### PR DESCRIPTION
It's not clean, it may not be clear, it adds unnecessary depth. If this a clean code guide, the suggested IF block has no place here as it's worse and dirtier than the other options.