### PR TITLE
Issue templates for Clean ABAP

### DIFF
--- a/.github/ISSUE_TEMPLATE/adjust-existing-rule.md
+++ b/.github/ISSUE_TEMPLATE/adjust-existing-rule.md
@@ -1,0 +1,16 @@
+---
+name: Adjust rule (Clean ABAP)
+about: Use this template to discuss changes to a rule in the Clean ABAP style guide
+title: "[RULE] your title here"
+labels: Adjustment Of Rule, clean-abap
+
+---
+
+**Relevant sections of the style guide**
+> Please link here to all relevant sections of the [Clean ABAP guide](https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md)
+
+**Description**
+> Please describe here what changes to the above sections you propose
+
+**Examples**
+> Please consider adding examples of patterns/anti-patterns this change suggests/avoids 

--- a/.github/ISSUE_TEMPLATE/adjust-existing-rule.md
+++ b/.github/ISSUE_TEMPLATE/adjust-existing-rule.md
@@ -1,7 +1,7 @@
 ---
 name: Adjust rule (Clean ABAP)
 about: Use this template to discuss changes to a rule in the Clean ABAP style guide
-title: "[name of rule] your title here"
+title: '[name of rule] your title here'
 labels: Adjustment Of Rule, clean-abap
 
 ---

--- a/.github/ISSUE_TEMPLATE/adjust-existing-rule.md
+++ b/.github/ISSUE_TEMPLATE/adjust-existing-rule.md
@@ -1,7 +1,7 @@
 ---
 name: Adjust rule (Clean ABAP)
 about: Use this template to discuss changes to a rule in the Clean ABAP style guide
-title: "[RULE] your title here"
+title: "[name of rule] your title here"
 labels: Adjustment Of Rule, clean-abap
 
 ---

--- a/.github/ISSUE_TEMPLATE/clarification.md
+++ b/.github/ISSUE_TEMPLATE/clarification.md
@@ -1,0 +1,14 @@
+---
+name: Clarification (Clean ABAP)
+about: Request clarification on a rule in the Clean ABAP style guide
+title: '[RULE] your title here'
+labels: unclear, clean-abap
+assignees: ''
+
+---
+
+**Relevant sections of the style guide**
+> Please link here to all relevant sections of the [Clean ABAP guide](https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md)
+
+**Question**
+> Please ask your question here

--- a/.github/ISSUE_TEMPLATE/clarification.md
+++ b/.github/ISSUE_TEMPLATE/clarification.md
@@ -1,7 +1,7 @@
 ---
 name: Clarification (Clean ABAP)
 about: Request clarification on a rule in the Clean ABAP style guide
-title: '[RULE] your title here'
+title: '[name of rule] your title here'
 labels: unclear, clean-abap
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/clarification.md
+++ b/.github/ISSUE_TEMPLATE/clarification.md
@@ -2,7 +2,7 @@
 name: Clarification (Clean ABAP)
 about: Request clarification on a rule in the Clean ABAP style guide
 title: '[name of rule] your title here'
-labels: unclear, clean-abap
+labels: Clarity of Text, clean-abap
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,0 +1,10 @@
+---
+name: Other issue (Clean ABAP)
+about: Report any other issue with the Clean ABAP style guide
+title: ''
+labels: clean-abap
+assignees: ''
+
+---
+
+> Report your issue here. Please directly link to all sections of the [style guide](https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md) you're discussing to make your issue simple to understand.

--- a/.github/ISSUE_TEMPLATE/propose-new-rule.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-rule.md
@@ -1,0 +1,15 @@
+---
+name: Propose new rule (Clean ABAP)
+about: Propose a new rule for the Clean ABAP style guide
+title: your title here
+labels: New Rule, clean-abap
+assignees: ''
+
+---
+
+**Proposed Rule**
+> Please formulate your proposed new rule here. Remember to include at least one example for a pattern suggested and an anti-pattern disallowed by the rule.
+
+**Justification**
+> Please provide the reasoning behind the rule here
+

--- a/.github/ISSUE_TEMPLATE/propose-new-rule.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-rule.md
@@ -1,7 +1,7 @@
 ---
 name: Propose new rule (Clean ABAP)
 about: Propose a new rule for the Clean ABAP style guide
-title: your title here
+title: 'your title here'
 labels: New Rule, clean-abap
 assignees: ''
 


### PR DESCRIPTION
This PR adds 4 issue templates for the Clean ABAP style guide for

- new rule proposals
- adjusting an existing rule
- clarification requests
- other issues

In particular, all issues created from these templates will be tagged with https://github.com/SAP/styleguides/labels/clean-abap and other labels that apply (e.g. https://github.com/SAP/styleguides/labels/New%20Rule).

It is possible that maintainers still need to activate using issue templates after merging this (cf. [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)), but I don't expect it to be necessary.