### PR TITLE
Recommend native ENUM over alternatives

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -54,8 +54,8 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
   - [Use design patterns wisely](#use-design-patterns-wisely)
 - [Constants](#constants)
   - [Use constants instead of magic numbers](#use-constants-instead-of-magic-numbers)
-  - [Prefer enumeration classes to constants interfaces](#prefer-enumeration-classes-to-constants-interfaces)
-  - [If you don't use enumeration classes, group your constants](#if-you-dont-use-enumeration-classes-group-your-constants)
+  - [Prefer ENUM to constants interfaces](#prefer-enum-to-constants-interfaces)
+  - [If you don't use ENUM or enumeration patterns, group your constants](#if-you-dont-use-enum-or-enumeration-patterns-group-your-constants)
 - [Variables](#variables)
   - [Prefer inline to up-front declarations](#prefer-inline-to-up-front-declarations)
   - [Don't declare inline in optional branches](#dont-declare-inline-in-optional-branches)
@@ -801,28 +801,19 @@ IF abap_type = 'D'.
 > Read more in _Chapter 17: Smells and Heuristics: G25:
 > Replace Magic Numbers with Named Constants_ of [Robert C. Martin's _Clean Code_].
 
-### Prefer enumeration classes to constants interfaces
+### Prefer ENUM to constants interfaces
 
-> [Clean ABAP](#clean-abap) > [Content](#content) > [Constants](#constants) > [This section](#prefer-enumeration-classes-to-constants-interfaces)
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Constants](#constants) > [This section](#prefer-enum-to-constants-interfaces)
+
+Use ABAP-native enumerations with `ENUM` (available in releases >= 7.51)
 
 ```ABAP
 CLASS /clean/message_severity DEFINITION PUBLIC ABSTRACT FINAL.
   PUBLIC SECTION.
-    CONSTANTS:
-      warning TYPE symsgty VALUE 'W',
-      error   TYPE symsgty VALUE 'E'.
-ENDCLASS.
-```
-
-or
-
-```ABAP
-CLASS /clean/message_severity DEFINITION PUBLIC CREATE PRIVATE FINAL.
-  PUBLIC SECTION.
-    CLASS-DATA:
-      warning TYPE REF TO /clean/message_severity READ-ONLY,
-      error   TYPE REF TO /clean/message_severity READ-ONLY.
-  " ...
+    TYPES: BEGIN OF ENUM type,
+             warning,
+             error,
+           END OF ENUM type.
 ENDCLASS.
 ```
 
@@ -842,16 +833,16 @@ ENDINTERFACE.
 ```
 
 > [Enumerations](sub-sections/Enumerations.md)
-> describes common enumeration patterns
+> describes alternative enumeration patterns (also applicable to older releases that do not support `ENUM` yet)
 > and discusses their advantages and disadvantages.
 >
 > Read more in _Chapter 17: Smells and Heuristics: J3: Constants versus Enums_ of [Robert C. Martin's _Clean Code_].
 
-### If you don't use enumeration classes, group your constants
+### If you don't use ENUM or enumeration patterns, group your constants
 
-> [Clean ABAP](#clean-abap) > [Content](#content) > [Constants](#constants) > [This section](#if-you-dont-use-enumeration-classes-group-your-constants)
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Constants](#constants) > [This section](#if-you-dont-use-enum-or-enumeration-patterns-group-your-constants)
 
-If you collect constants in a loose way, for example in an interface, group them:
+If you cannot use enumerations and have to collect constants in a loose way, for example in an interface, at least group them:
 
 ```ABAP
 CONSTANTS:
@@ -865,7 +856,7 @@ CONSTANTS:
   END OF message_lifespan.
 ```
 
-Makes the relation clearer than:
+makes the relation clearer than
 
 ```ABAP
 " Anti-pattern

--- a/clean-abap/sub-sections/Enumerations.md
+++ b/clean-abap/sub-sections/Enumerations.md
@@ -50,6 +50,22 @@ used as
 IF log_contains( /clean/message_severity=>warning ).
 ```
 
+> Note that the [`STRUCTURE` addition](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/index.htm?file=abaptypes_enum.htm#!ABAP_ADDITION_1@1@) **is not used**.
+>
+> One reason is that this would widen the API surface without the requiremend to do so.
+> If the definition was `BEGIN OF ENUM type STRUCTURE severity` then `/dirty/message_severity=>severity` could be copied and passed around which is undesirable.
+>
+> Another reason is the additional grouping level that `STRUCTURE` introduces:
+> If an enumeration value is used there is duplication that does not bring any semantic benefit:
+> `/dirty/message_severity=>severity-warning` for example repeats the word "_severity_".
+> A rather short-sighted reaction could be cutting that word from the class name.
+> The remaining `/dirty/message=>severity`, however, misleads as for the purpose of the class `/dirty/message` - after all it deals only with message severities and not with messages in general.
+> If further enumerations were to be added to that class its purpose would become unclear thus violating the single-responsibility principle.
+>
+> Thus declaring exactly one enumeration **without** `STRUCTURE` in a dedicated class should be preferred.
+> It yields nicely addressable top-level enumeration values (see example at the beginning of this section).
+> Prefer treating enumerations as first-class citizens and do not introduce unnecessary depth with structures.
+
 ### Compatibility
 
 To integrate native enumerations with legacy code that uses constants the `BASE TYPE` addition is available:

--- a/clean-abap/sub-sections/Enumerations.md
+++ b/clean-abap/sub-sections/Enumerations.md
@@ -75,13 +75,16 @@ CLASS /compatbl/message_severity DEFINITION PUBLIC ABSTRACT FINAL.
     TYPES: BEGIN OF ENUM type BASE TYPE symsgty,
             info      VALUE 'I',
             exit      VALUE 'X',
-            undefined IS INITIAL,
+            undefined VALUE IS INITIAL,
           END OF ENUM type.
 ```
 This allows a conversion from and to enumerated variables using the `CONV` operator.
 ```ABAP
-DATA(severity_as_char) = CONV symsgty( /compatbl/message_severity=>info ). "yields 'I'
-DATA(severity) = CONV /compatbl/message_severity=>type( 'X' ). "yields /compatbl/message_severity=>exit
+"yields 'I'
+DATA(severity_as_char) = CONV symsgty( /compatbl/message_severity=>info ). 
+
+"yields /compatbl/message_severity=>exit
+DATA(severity) = CONV /compatbl/message_severity=>type( 'X' ). 
 ```
 
 The conversion operator is mandatory to satisfy the strict type check.


### PR DESCRIPTION
This proposal recommends `ENUM` over enumeration patterns. `ENUM` has the obvious advantage of being native to the language with both syntax checks and type-safe compilation.

In the main styleguide `ENUM` is therefore recommended over constants interfaces. The enumeration subtopic has been adjusted as well to reflect that recommendation, yet present all object-oriented alternative patterns as before.