### PR TITLE
New Syntax ASSIGN, dynamic_components

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -880,7 +880,6 @@ The group also allows you group-wise access, for example for input validation:
 
 ```ABAP
 DO.
-  ASSIGN COMPONENT sy-index OF STRUCTURE message_severity 
   ASSIGN message_severity-(sy-index) TO FIELD-SYMBOL(<constant>).
   IF sy-subrc IS INITIAL.
     IF input = <constant>.

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -880,7 +880,8 @@ The group also allows you group-wise access, for example for input validation:
 
 ```ABAP
 DO.
-  ASSIGN COMPONENT sy-index OF STRUCTURE message_severity TO FIELD-SYMBOL(<constant>).
+  ASSIGN COMPONENT sy-index OF STRUCTURE message_severity 
+  ASSIGN message_severity-(sy-index) TO FIELD-SYMBOL(<constant>).
   IF sy-subrc IS INITIAL.
     IF input = <constant>.
       DATA(is_valid) = abap_true.
@@ -1011,7 +1012,7 @@ except where you need field symbols
 
 ```ABAP
 ASSIGN generic->* TO FIELD-SYMBOL(<generic>).
-ASSIGN COMPONENT name OF STRUCTURE structure TO FIELD-SYMBOL(<component>).
+ASSIGN structure-(name) TO FIELD-SYMBOL(<component>).
 ASSIGN (class_name)=>(static_member) TO FIELD-SYMBOL(<member>).
 ```
 


### PR DESCRIPTION
Change example to newly available, preferred syntax.

https://blogs.sap.com/2022/03/28/new-kinds-of-abap-expressions-part-ii/#:~:text=2.%20Using%20dynamic%20structure%20component%20expressions%20in%20ASSIGN

https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abapassign_dynamic_components.htm