### PR TITLE
empty lines inside statement

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3959,7 +3959,7 @@ METHOD do_something.
 ENDMETHOD.
 ```
 
-This is also the case within a statment, as this can easily be seen as a new statement when looking through the code.
+This is also the case within a statement, as this can easily be misunderstood as a new statement when skimming through the code.
 ```abap
 " anti-pattern
 DATA(result) = merge_structures( a = VALUE #( field_1 = 'X'

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3959,6 +3959,16 @@ METHOD do_something.
 ENDMETHOD.
 ```
 
+This is also the case within a statment, as this can easily be seen as a new statement when looking through the code.
+```abap
+" anti-pattern
+DATA(result) = merge_structures( a = VALUE #( field_1 = 'X'
+                                              field_2 = 'A' )
+
+                                 b = NEW /clean/structure_type( field_3 = 'C'
+                                                                field_4 = 'D' ) ).
+```
+
 Blank lines actually only make sense if you have statements that span multiple lines
 
 ```ABAP


### PR DESCRIPTION
This PR contains minor adjustment to improve the formatting section and to close [issue 170](https://github.com/SAP/styleguides/issues/170). 

I personally thought that it does not make sense to draft a new rule, as section [Don't obsess with separating blank lines](https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#dont-obsess-with-separating-blank-lines) already expresses the same or has at least the same meaning. Hence the anti-pattern provided within the issue has been appended to the section.
