### PR TITLE
Update CleanABAP.md - new rule "use snake_case"

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -464,7 +464,7 @@ for example prefer `detection_object_types` to something cryptic like `dobjt`.
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Names](#names) > [This section](#use-snake_case)
 
 ABAP is case insensitive and limits the number of available letters for naming all kind of DDIC-objects
-and variables. For exampe the maximum length of a method name is 30 characters. The defacto naming convention
+and variables. For example the maximum length of a method name is 30 characters. The defacto naming convention
 in ABAP is `snake_case`, because camelCase is overwritten when the Pretty Printer is activated and not all team
 members use the 'Keep Camel Case Identifiers' setting in the ADT ABAP Formatter. Also `camelCase` doesn't
 affect DDIC-objects.

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -469,9 +469,14 @@ There's a character limit for names, e.g. 30 characters for methods. When you re
 
 ```ABAP
 " a variable which contains the maximum reponse time measured in milliseconds
+DATA max_response_time_in_millisec TYPE i.
+```
 
-max_response_time_in_millisec " ok
-maxresponsetimeinmilliseconds " bad practice
+is better than
+
+```ABAP
+" anti-pattern
+DATA maxresponsetimeinmilliseconds TYPE i.
 ```
 
 ### Avoid abbreviations

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -468,9 +468,10 @@ ABAP is case insensitive which is why we recommend following the convention to u
 There's a character limit for names, e.g. 30 characters for methods. When you reach the maximum length of an object, don't fall back to using `flatcase` or `UPPERCASE`. Try to conscientiously use abbreviations instead (see [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)).
 
 ```ABAP
-" a variable which contains the reponse time measured in milliseconds
-response_time_in_millisec  " ok
-responsetimeinmilliseconds " bad practice
+" a variable which contains the maximum reponse time measured in milliseconds
+
+max_response_time_in_millisec " ok
+maxresponsetimeinmilliseconds " bad practice
 ```
 
 ### Avoid abbreviations

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -465,8 +465,7 @@ for example prefer `detection_object_types` to something cryptic like `dobjt`.
 
 ABAP is case insensitive and limits the number of available letters for naming all kind of DDIC-objects
 and variables. For example the maximum length of a method name is 30 characters. The defacto naming convention
-in ABAP is `snake_case`, because camelCase is overwritten when the Pretty Printer is activated and not all team
-members use the 'Keep Camel Case Identifiers' setting in the ADT ABAP Formatter. Also `camelCase` doesn't
+in ABAP is `snake_case`, because ABAP is not case sensitive and camelCase is overwritten when the Pretty Printer / Formatter is activated and not all team members use the 'Keep Camel Case Identifiers' setting in the ADT ABAP Formatter. Also `camelCase` doesn't
 affect DDIC-objects.
 We recommend using `snake_case` consistently instead of `flatcase` or `UPPERCASE`. When you reach the maximum 
 length of an object, try to conscientiously use abbreviations (see [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)).

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -463,12 +463,9 @@ for example prefer `detection_object_types` to something cryptic like `dobjt`.
 ### Use snake_case
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Names](#names) > [This section](#use-snake_case)
 
-ABAP is case insensitive and limits the number of available letters for naming all kind of DDIC-objects
-and variables. For example the maximum length of a method name is 30 characters. The defacto naming convention
-in ABAP is `snake_case`, because ABAP is not case sensitive and camelCase is overwritten when the Pretty Printer / Formatter is activated and not all team members use the 'Keep Camel Case Identifiers' setting in the ADT ABAP Formatter. Also `camelCase` doesn't
-affect DDIC-objects.
-We recommend using `snake_case` consistently instead of `flatcase` or `UPPERCASE`. When you reach the maximum 
-length of an object, try to conscientiously use abbreviations (see [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)).
+ABAP is case insensitive which is why we recommend following the convention to use `snake_case` consistently.
+
+There's a character limit for names, e.g. 30 characters for methods. When you reach the maximum length of an object, don't fall back to using `flatcase` or `UPPERCASE`. Try to conscientiously use abbreviations instead (see [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)).
 
 ```ABAP
 " a variable which contains the reponse time measured in milliseconds

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -461,7 +461,7 @@ for example prefer `detection_object_types` to something cryptic like `dobjt`.
 > Read more in _Chapter 2: Meaningful Names: Use Pronounceable Names_ of [Robert C. Martin's _Clean Code_]
 
 ### Use snake_case
-> [Clean ABAP](#clean-abap) > [Content](#content) > [Names](#names) > [This section](#use-snake-case)
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Names](#names) > [This section](#use-snake_case)
 
 ABAP is case insensitive and limits the number of available letters for naming all kind of DDIC-objects
 and variables. For exampe the maximum length of a method name is 30 characters. The defacto naming convention

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -472,7 +472,7 @@ We recommend using `snake_case` consistently instead of `flatcase` or `UPPERCASE
 length of an object, try to conscientiously use abbreviations (see [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)).
 
 ```ABAP
-* a variable which contains the reponse time measured in milliseconds
+" a variable which contains the reponse time measured in milliseconds
 response_time_in_millisec  " ok
 responsetimeinmilliseconds " bad practice
 ```

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -469,7 +469,7 @@ in ABAP is `snake_case`, because camelCase is overwritten when the Pretty Printe
 members use the 'Keep Camel Case Identifiers' setting in the ADT ABAP Formatter. Also `camelCase` doesn't
 affect DDIC-objects.
 We recommend using `snake_case` consistently instead of `flatcase` or `UPPERCASE`. When you reach the maximum 
-length of an object, try to conscientiously use abbreviations (also see [Avoid abbreviations](#avoid-abbreviations)).
+length of an object, try to conscientiously use abbreviations (see [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)).
 
 ```ABAP
 * a variable which contains the reponse time measured in milliseconds

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -37,6 +37,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
   - [Prefer solution domain and problem domain terms](#prefer-solution-domain-and-problem-domain-terms)
   - [Use plural](#use-plural)
   - [Use pronounceable names](#use-pronounceable-names)
+  - [Use snake_case](#use-snake_case)
   - [Avoid abbreviations](#avoid-abbreviations)
   - [Use same abbreviations everywhere](#use-same-abbreviations-everywhere)
   - [Use nouns for classes and verbs for methods](#use-nouns-for-classes-and-verbs-for-methods)
@@ -458,6 +459,23 @@ We think and talk a lot about objects, so use names that you can pronounce,
 for example prefer `detection_object_types` to something cryptic like `dobjt`.
 
 > Read more in _Chapter 2: Meaningful Names: Use Pronounceable Names_ of [Robert C. Martin's _Clean Code_]
+
+### Use snake_case
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Names](#names) > [This section](#use-snake-case)
+
+ABAP is case insensitive and limits the number of available letters for naming all kind of DDIC-objects
+and variables. For exampe the maximum length of a method name is 30 characters. The defacto naming convention
+in ABAP is `snake_case`, because camelCase is overwritten when the Pretty Printer is activated and not all team
+members use the 'Keep Camel Case Identifiers' setting in the ADT ABAP Formatter. Also `camelCase` doesn't
+affect DDIC-objects.
+We recommend using `snake_case` consistently instead of `flatcase` or `UPPERCASE`. When you reach the maximum 
+length of an object, try to conscientiously use abbreviations (also see [Avoid abbreviations](#avoid-abbreviations)).
+
+```ABAP
+* a variable which contains the reponse time measured in milliseconds
+response_time_in_millisec  " ok
+responsetimeinmilliseconds " bad practice
+```
 
 ### Avoid abbreviations
 


### PR DESCRIPTION
- the examples in the styleguide use snake_case, but its not directly recommended in the main document. 
- the possibilities of the ADT Formatter haven't been considered(?)
- the common bad practice "switch from camel_case to UPPERCASE when you reach the maximum length of an object" hasn't been addressed
