### PR TITLE
Use descriptive names for constants

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -55,6 +55,7 @@ The [Cheat Sheet](cheat-sheet/CheatSheet.md) is a print-optimized version.
   - [Use design patterns wisely](#use-design-patterns-wisely)
 - [Constants](#constants)
   - [Use constants instead of magic numbers](#use-constants-instead-of-magic-numbers)
+  - [Constants also need descriptive names](#constants-also-need-descriptive-names)  
   - [Prefer ENUM to constants interfaces](#prefer-enum-to-constants-interfaces)
   - [If you don't use ENUM or enumeration patterns, group your constants](#if-you-dont-use-enum-or-enumeration-patterns-group-your-constants)
 - [Variables](#variables)
@@ -825,6 +826,27 @@ IF abap_type = 'D'.
 
 > Read more in _Chapter 17: Smells and Heuristics: G25:
 > Replace Magic Numbers with Named Constants_ of [Robert C. Martin's _Clean Code_].
+
+### Constants also need descriptive names
+
+> [Clean ABAP](#clean-abap) > [Content](#content) > [Constants](#constants) > [This section](#constants-also-need-descriptive-names)
+
+There is a historic tendency in ABAP to wrap every literal in constants with names 
+that merely repeat their content or even their type:
+```ABAP
+" anti-pattern 
+CONSTANTS: 
+  c_01 TYPE spart VALUE '01',
+  c_mmsta TYPE mmsta VALUE '90'.
+```
+There is little benefit to either variant. It is not informative for the reader, and if 
+the value ever needs to change then a constant named by its value must also be renamed. 
+
+If a constant is declared in code then it should describe its meaning not its content.
+```ABAP
+CONSTANTS status_inactive TYPE mmsta VALUE '90'.
+```
+Note: This is a special case of [Use descriptive names](#use-descriptive-names), specifically for constants.
 
 ### Prefer ENUM to constants interfaces
 

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -831,8 +831,8 @@ IF abap_type = 'D'.
 
 > [Clean ABAP](#clean-abap) > [Content](#content) > [Constants](#constants) > [This section](#constants-also-need-descriptive-names)
 
-There is a historic tendency in ABAP to wrap every literal in constants with names 
-that merely repeat their content or even their type:
+There is a historic tendency in ABAP to wrap every literal in constants, often with names 
+that merely repeat their content or even just their type:
 ```ABAP
 " anti-pattern 
 CONSTANTS: 
@@ -842,11 +842,16 @@ CONSTANTS:
 There is little benefit to either variant. It is not informative for the reader, and if 
 the value ever needs to change then a constant named by its value must also be renamed. 
 
-If a constant is declared in code then it should describe its meaning not its content.
+If a coded constant is declared in code then it should describe its meaning not its content.
 ```ABAP
 CONSTANTS status_inactive TYPE mmsta VALUE '90'.
 ```
-Note: This is a special case of [Use descriptive names](#use-descriptive-names), specifically for constants.
+It is of course acceptable to repeat the constant's value if it is already descriptive enough: 
+```ABAP
+CONSTANTS status_cancelled TYPE sww_wistat value 'CANCELLED'.
+```
+
+Note: This section is a repetition of [Use descriptive names](#use-descriptive-names), specifically for constants.
 
 ### Prefer ENUM to constants interfaces
 

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -851,7 +851,7 @@ It is of course acceptable to repeat the constant's value if it is already descr
 CONSTANTS status_cancelled TYPE sww_wistat value 'CANCELLED'.
 ```
 
-Note: This section is a repetition of [Use descriptive names](#use-descriptive-names), specifically for constants.
+> Note: This section is a specialization of [Use descriptive names](#use-descriptive-names), applied to constants.
 
 ### Prefer ENUM to constants interfaces
 


### PR DESCRIPTION
This PR continues #198 - GitHub automatically closed it when I synched my fork. 

There is still a lot of code being written in the style of `CONSTANTS c_01 TYPE ... VALUE '01'.`, I suggest this should be emphasised in its own section.

I moved it to the constants section as requested and also removed the prefix. 

That said, personally I still use `c_` prefix for constants as an exception to the "don't prefix" rule. Everyone knows it and it has value to differentiate a constant from an attribute. Other languages that otherwise don't use prefixes still have their way of visually hilighting constants - JS and C++ tend to use CAPS.