### PR TITLE
Clarify ADT ABAP Formatter Settings

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3916,7 +3916,8 @@ in a separate Transport Request or Note.
 
 Always use your team's ABAP Formatter settings.
 Specify them under
-* Eclipse: _Menu_ > _Window_ > _Preferences_ > _ABAP Development_ > _Editors_ > _Source Code Editors_ > _ABAP Formatter_
+* Eclipse: Right-click on the project in the Project Explorer > _Properties_ > _ABAP Development_ > _Editors_ > _Source Code Editors_ > _ABAP Formatter_
+* Eclipse (alternative navigation): _Menu_ > _Window_ > _Preferences_ > _ABAP Development_ > _Editors_ > _Source Code Editors_ > Click on the _ABAP Formatter_ link on the right-hand side_ > Select project in pop-up
 * SAP GUI: _Menu_ > _Utilities_ > _Settings ..._ > _ABAP Editor_ > _Pretty Printer_.
 
 Set _Indent_ and _Convert Uppercase/Lowercase_ > _Uppercase Keyword_

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -3917,7 +3917,7 @@ in a separate Transport Request or Note.
 Always use your team's ABAP Formatter settings.
 Specify them under
 * Eclipse: Right-click on the project in the Project Explorer > _Properties_ > _ABAP Development_ > _Editors_ > _Source Code Editors_ > _ABAP Formatter_
-* Eclipse (alternative navigation): _Menu_ > _Window_ > _Preferences_ > _ABAP Development_ > _Editors_ > _Source Code Editors_ > Click on the _ABAP Formatter_ link on the right-hand side_ > Select project in pop-up
+* Eclipse (alternative navigation): _Menu_ > _Window_ > _Preferences_ > _ABAP Development_ > _Editors_ > _Source Code Editors_ > Click on the _ABAP Formatter_ link on the right-hand side > Select project in pop-up
 * SAP GUI: _Menu_ > _Utilities_ > _Settings ..._ > _ABAP Editor_ > _Pretty Printer_.
 
 Set _Indent_ and _Convert Uppercase/Lowercase_ > _Uppercase Keyword_


### PR DESCRIPTION
Make description on how to find Formatter settings in ADT clearer.  

Previous:

<img width="427" alt="image" src="https://github.com/SAP/styleguides/assets/17111602/375c2158-4313-42d9-9725-e100057cafc6">     

Based on the description, I expected that the ABAP Formatter is in the tree. It took me a bit to see that there is only a link on the right-hand side to the project settings.

<img width="366" alt="image" src="https://github.com/SAP/styleguides/assets/17111602/c4840042-7e90-4a7a-8092-57fa85c6ceef"> 
