### PR TITLE
Removal of dead or questionable links in section "split-method-instead-of-boolean-input-parameter" across multiple languages

### DIFF
--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2706,7 +2706,9 @@ METHODS set_is_deleted
 ```
 
 > Read more in
-> [1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Parameter Names
 

--- a/clean-abap/CleanABAP.md
+++ b/clean-abap/CleanABAP.md
@@ -2706,8 +2706,7 @@ METHODS set_is_deleted
 ```
 
 > Read more in
-> [1](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
-> [2](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Parameter Names
 

--- a/clean-abap/CleanABAP_de.md
+++ b/clean-abap/CleanABAP_de.md
@@ -2323,7 +2323,9 @@ METHODS set_is_deleted
 ```
 
 > Mehr erfahren Sie in
-[1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html).
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Parameternamen
 

--- a/clean-abap/CleanABAP_de.md
+++ b/clean-abap/CleanABAP_de.md
@@ -2323,9 +2323,7 @@ METHODS set_is_deleted
 ```
 
 > Mehr erfahren Sie in
-[1](http://www.beyondcode.org/articles/booleanVariables.html),
-[2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/) und
-[3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html).
+[1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html).
 
 ### Parameternamen
 

--- a/clean-abap/CleanABAP_es.md
+++ b/clean-abap/CleanABAP_es.md
@@ -2588,7 +2588,9 @@ METHODS set_is_deleted
 ```
 
 > Lee más en
-> [1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Nombres de parámetros
 

--- a/clean-abap/CleanABAP_es.md
+++ b/clean-abap/CleanABAP_es.md
@@ -2588,9 +2588,7 @@ METHODS set_is_deleted
 ```
 
 > Lee más en
-> [1](http://www.beyondcode.org/articles/booleanVariables.html)
-> [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
-> [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Nombres de parámetros
 

--- a/clean-abap/CleanABAP_fr.md
+++ b/clean-abap/CleanABAP_fr.md
@@ -2178,7 +2178,10 @@ METHODS set_is_deleted
     new_value TYPE abap_bool.
 ```
 
-> Pour en savoir plus, lisez [1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> Pour en savoir plus, lisez
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Noms de paramètres
 

--- a/clean-abap/CleanABAP_fr.md
+++ b/clean-abap/CleanABAP_fr.md
@@ -2178,7 +2178,7 @@ METHODS set_is_deleted
     new_value TYPE abap_bool.
 ```
 
-> Pour en savoir plus, lisez [1](http://www.beyondcode.org/articles/booleanVariables.html) [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/) [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> Pour en savoir plus, lisez [1](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Noms de paramètres
 

--- a/clean-abap/CleanABAP_ja.md
+++ b/clean-abap/CleanABAP_ja.md
@@ -2325,7 +2325,10 @@ METHODS set_is_deleted
 ```
 
 > 詳細は
-> [1](http://www.beyondcode.org/articles/booleanVariables.html) > [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/) > [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+
 
 ### パラメータ名
 

--- a/clean-abap/CleanABAP_kr.md
+++ b/clean-abap/CleanABAP_kr.md
@@ -2424,9 +2424,9 @@ METHODS set_is_deleted
 ```
 
 > 아래에서 더 많은 정보를 얻으세요.
-> [1](http://www.beyondcode.org/articles/booleanVariables.html)
-> [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
-> [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### 파라미터명
 

--- a/clean-abap/CleanABAP_ru.md
+++ b/clean-abap/CleanABAP_ru.md
@@ -2615,9 +2615,9 @@ METHODS set_is_deleted
 ```
 
 > Подробнее в
-> [1](http://www.beyondcode.org/articles/booleanVariables.html)
-> [2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
-> [3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
 
 ### Имена параметров
 

--- a/clean-abap/CleanABAP_zh.md
+++ b/clean-abap/CleanABAP_zh.md
@@ -2178,7 +2178,11 @@ METHODS set_is_deleted
     new_value TYPE abap_bool.
 ```
 
-> 有关详细信息，请参阅[1](http://www.beyondcode.org/articles/booleanVariables.html)[2](https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)[3](http://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+> 有关详细信息，请参阅
+> [1](https://web.archive.org/web/20190907112758/http://www.beyondcode.org/articles/booleanVariables.html)
+> [2](https://web.archive.org/web/20220314024954/https://silkandspinach.net/2004/07/15/avoid-boolean-parameters/)
+> [3](https://web.archive.org/web/20231211152320/https://jlebar.com/2011/12/16/Boolean_parameters_to_API_functions_considered_harmful..html)
+
 
 ### 参数名称
 


### PR DESCRIPTION
Related to this [issue](https://github.com/SAP/styleguides/issues/344). Removal of certain links in the English, Spanish, German and French version of the document.